### PR TITLE
skip CMake 3.30.0, add flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+[flake8]
+filename = *.py, *.pyx, *.pxd, *.pxi
+exclude = __init__.py, *.egg, build, docs, .git
+force-check = True
+max-line-length = 88
+ignore =
+    # line break before binary operator
+    W503,
+    # whitespace before :
+    E203
+per-file-ignores =
+    # Rules ignored only in Cython:
+    # E211: whitespace before '(' (used in multi-line imports)
+    # E225: Missing whitespace around operators (breaks cython casting syntax like <int>)
+    # E226: Missing whitespace around arithmetic operators (breaks cython pointer syntax like int*)
+    # E227: Missing whitespace around bitwise or shift operator (Can also break casting syntax)
+    # E275: Missing whitespace after keyword (Doesn't work with Cython except?)
+    # E402: invalid syntax (works for Python, not Cython)
+    # E999: invalid syntax (works for Python, not Cython)
+    # W504: line break after binary operator (breaks lines that end with a pointer)
+    *.pyx: E211, E225, E226, E227, E275, E402, E999, W504
+    *.pxd: E211, E225, E226, E227, E275, E402, E999, W504
+    *.pxi: E211, E225, E226, E227, E275, E402, E999, W504

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -10,7 +10,7 @@ channels:
 - nvidia
 dependencies:
 - breathe
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-nvtx
 - cuda-version=11.8
 - cudatoolkit

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -10,7 +10,7 @@ channels:
 - nvidia
 dependencies:
 - breathe
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-cudart-dev
 - cuda-nvtx-dev
 - cuda-profiler-api

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -61,7 +61,7 @@ files:
       - py_version
       - test_python_common
       - test_python_pylibcugraph
- 
+
   py_build_cugraph_dgl:
     output: pyproject
     pyproject_dir: python/cugraph-dgl
@@ -110,8 +110,8 @@ files:
     includes:
       - test_python_common
       - depends_on_pylibwholegraph
-  
-  
+
+
   cugraph_dgl_dev:
     matrix:
       cuda: ["11.8"]
@@ -199,7 +199,7 @@ dependencies:
     common:
       - output_types: [conda, pyproject]
         packages:
-          - &cmake_ver cmake>=3.26.4
+          - &cmake_ver cmake>=3.26.4,!=3.30.0
           - ninja
 
   docs:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/80

Adds constraints to avoid pulling in CMake 3.30.0, for the reasons described in that issue.

## Notes for Reviewers

This also adds a `.flake8` file (exactly copied from `cugraph`'s, with only the copyright changed), so that `pre-commit run` can pass. Without it, the `flake8` check fails like this:

```text
There was a critical error during execution of Flake8:
The specified config file does not exist: .flake8
```

Whitespace-only changes in this PR were made by `pre-commit run --all-files`.