### PR TITLE
add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,25 @@
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# Order matters - match of highest importance goes last (last match wins)
+
+# doc code owners
+/img               @rapidsai/cugraph-doc-codeowners
+/readme_pages/     @rapidsai/cugraph-doc-codeowners
+
+# python code owners
+python/            @rapidsai/cugraph-python-codeowners
+mg_utils/          @rapidsai/cugraph-python-codeowners
+
+# CI code owners
+/.flake8                 @rapidsai/ci-codeowners
+/.github/                @rapidsai/ci-codeowners
+/ci/                     @rapidsai/ci-codeowners
+/.codecov.yml            @rapidsai/ci-codeowners
+/.pre-commit-config.yaml @rapidsai/ci-codeowners
+/print_env.sh            @rapidsai/ci-codeowners
+
+# packaging code owners
+/conda/            @rapidsai/packaging-codeowners
+/dependencies.yaml @rapidsai/packaging-codeowners
+/build.sh          @rapidsai/packaging-codeowners
+pyproject.toml     @rapidsai/packaging-codeowners
+VERSION            @rapidsai/packaging-codeowners


### PR DESCRIPTION
Proposes adding a CODEOWNERS file to auto-assign reviewers.

This is mostly based on https://github.com/rapidsai/cugraph/blob/branch-24.08/.github/CODEOWNERS and https://github.com/rapidsai/cugraph/pull/4409, with some small changes based on the current contents of this repo (e.g., no C++ code so no `cugraph-cpp-codeowners`).

## Notes for Reviewers

This won't work until these groups are added as collaborators with write access here. I've put up an ops request for that.