### PR TITLE
upgrade target Python version for black to 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: black
         language_version: python3
-        args: [--target-version=py39]
+        args: [--target-version=py310]
         files: ^(python/.*|benchmarks/.*)$
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/88.

Fixes one Python 3.9 to 3.10 upgrade that was missed in #32.