### PR TITLE
enforce wheel size limits, README formatting in CI

### DIFF
--- a/ci/build_wheel_cugraph-dgl.sh
+++ b/ci/build_wheel_cugraph-dgl.sh
@@ -3,4 +3,7 @@
 
 set -euo pipefail
 
-./ci/build_wheel.sh cugraph-dgl python/cugraph-dgl
+package_dir="python/cugraph-dgl"
+
+./ci/build_wheel.sh cugraph-dgl ${package_dir}
+./ci/validate_wheel.sh ${package_dir} dist

--- a/ci/build_wheel_cugraph-pyg.sh
+++ b/ci/build_wheel_cugraph-pyg.sh
@@ -3,4 +3,7 @@
 
 set -euo pipefail
 
-./ci/build_wheel.sh cugraph-pyg python/cugraph-pyg
+package_dir="python/cugraph-pyg"
+
+./ci/build_wheel.sh cugraph-pyg ${package_dir}
+./ci/validate_wheel.sh ${package_dir} dist

--- a/ci/build_wheel_pylibwholegraph.sh
+++ b/ci/build_wheel_pylibwholegraph.sh
@@ -3,6 +3,9 @@
 
 set -euo pipefail
 
+package_dir="python/pylibwholegraph"
+
 export SKBUILD_CMAKE_ARGS="-DDETECT_CONDA_ENV=OFF;-DBUILD_SHARED_LIBS=OFF;-DCMAKE_MESSAGE_LOG_LEVEL=VERBOSE;-DCUDA_STATIC_RUNTIME=ON;-DWHOLEGRAPH_BUILD_WHEELS=ON"
 
-./ci/build_wheel.sh pylibwholegraph python/pylibwholegraph
+./ci/build_wheel.sh pylibwholegraph ${package_dir}
+./ci/validate_wheel.sh ${package_dir} final_dist

--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+package_dir=$1
+wheel_dir_relative_path=$2
+
+cd "${package_dir}"
+
+rapids-logger "validate packages with 'pydistcheck'"
+
+pydistcheck \
+    --inspect \
+    "$(echo ${wheel_dir_relative_path}/*.whl)"
+
+rapids-logger "validate packages with 'twine'"
+
+twine check \
+    --strict \
+    "$(echo ${wheel_dir_relative_path}/*.whl)"

--- a/python/cugraph-dgl/pyproject.toml
+++ b/python/cugraph-dgl/pyproject.toml
@@ -60,3 +60,11 @@ include = [
 build-backend = "setuptools.build_meta"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
+
+[tool.pydistcheck]
+select = [
+    "distro-too-large-compressed",
+]
+
+# PyPI limit is 100 MiB, fail CI before we get too close to that
+max_allowed_size_compressed = '75M'

--- a/python/cugraph-pyg/README.md
+++ b/python/cugraph-pyg/README.md
@@ -1,0 +1,5 @@
+# cugraph-pyg
+
+## Description
+
+cuGraph-PyG supports PyTorch Geometric (PyG) and implements PyG's GraphStore, FeatureStore, Loader, and Sampler interfaces.

--- a/python/cugraph-pyg/pyproject.toml
+++ b/python/cugraph-pyg/pyproject.toml
@@ -70,3 +70,11 @@ include = [
 build-backend = "setuptools.build_meta"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
+
+[tool.pydistcheck]
+select = [
+    "distro-too-large-compressed",
+]
+
+# PyPI limit is 100 MiB, fail CI before we get too close to that
+max_allowed_size_compressed = '75M'

--- a/python/cugraph-pyg/pyproject.toml
+++ b/python/cugraph-pyg/pyproject.toml
@@ -16,6 +16,7 @@ testpaths = ["cugraph_pyg/tests"]
 name = "cugraph-pyg"
 dynamic = ["version"]
 description = "cugraph-pyg - PyG support for cuGraph massive-scale, ultra-fast GPU graph analytics."
+readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]

--- a/python/pylibwholegraph/README.md
+++ b/python/pylibwholegraph/README.md
@@ -1,0 +1,5 @@
+# pylibwholegraph
+
+WholeGraph supports PyTorch and provides a distributed graph and kv store.
+
+Both cuGraph-DGL and cuGraph-PyG can leverage WholeGraph for even greater scalability.

--- a/python/pylibwholegraph/pyproject.toml
+++ b/python/pylibwholegraph/pyproject.toml
@@ -74,3 +74,11 @@ wheel.packages = ["pylibwholegraph"]
 provider = "scikit_build_core.metadata.regex"
 input = "pylibwholegraph/VERSION"
 regex = "(?P<value>.*)"
+
+[tool.pydistcheck]
+select = [
+    "distro-too-large-compressed",
+]
+
+# detect when package size grows significantly
+max_allowed_size_compressed = '350M'

--- a/python/pylibwholegraph/pyproject.toml
+++ b/python/pylibwholegraph/pyproject.toml
@@ -23,6 +23,7 @@ requires = [
 name = "pylibwholegraph"
 dynamic = ["version"]
 description = "pylibwholegraph - GPU Graph Storage for GNN feature and graph structure"
+readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/110

Proposes adding 2 types of validation on wheels in CI, to ensure we continue to produce wheels that are suitable for PyPI.

* checks on wheel size (compressed),
  - *to be sure they're under PyPI limits*
  - *and to prompt discussion on PRs that significantly increase wheel sizes*
* checks on README formatting
  - *to ensure they'll render properly as the PyPI project homepages*
  - *e.g. like how https://github.com/scikit-learn/scikit-learn/blob/main/README.rst becomes https://pypi.org/project/scikit-learn/*
