### PR TITLE
remove versioning workaround for nightlies

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -13,11 +13,7 @@ export CMAKE_GENERATOR=Ninja
 
 rapids-print-env
 
-# TODO: revert this once we start publishing nightly packages
-#       from the 'cugraph-gnn' repo and stop publishing them from
-#       the 'cugraph' / 'wholegraph' repos
-#version=$(rapids-generate-version)
-version="24.12.00a1000"
+version=$(rapids-generate-version)
 
 rapids-logger "Begin cpp build"
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -15,11 +15,7 @@ rapids-print-env
 
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
-# TODO: revert this once we start publishing nightly packages
-#       from the 'cugraph-gnn' repo and stop publishing them from
-#       the 'cugraph' / 'wholegraph' repos
-# rapids-generate-version > ./VERSION
-echo "24.12.00a1000" > ./VERSION
+rapids-generate-version > ./VERSION
 
 sccache --zero-stats
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -84,3 +84,8 @@ for DEP in "${DEPENDENCIES[@]}"; do
 done
 
 sed_runner "s/\(PROJECT_NUMBER[[:space:]]*\)=.*/\1= ${NEXT_SHORT_TAG}/" cpp/Doxyfile
+
+# CI files
+for FILE in .github/workflows/*.yaml; do
+  sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+done

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -26,14 +26,11 @@ rapids-logger "Downloading artifacts from previous jobs"
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
 
-# TODO: remove the '>=24.12.00a1000' once we start publishing nightly packages
-#       from the 'cugraph-gnn' repo and stop publishing them from
-#       the 'cugraph' / 'wholegraph' repos
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   --channel "${PYTHON_CHANNEL}" \
   --channel dglteam/label/th23_cu118 \
-  "cugraph-dgl=${RAPIDS_VERSION},>=24.12.00a1000"
+  "cugraph-dgl=${RAPIDS_VERSION}"
 
 NBTEST="$(realpath "$(dirname "$0")/utils/nbtest.sh")"
 NOTEBOOK_LIST="$(realpath "$(dirname "$0")/notebook_list.py")"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -64,9 +64,6 @@ if [[ "${RUNNER_ARCH}" != "ARM64" ]]; then
   fi
 
 
-  # TODO: remove the '>=24.12.00a1000' once we start publishing nightly packages
-  #       from the 'cugraph-gnn' repo and stop publishing them from
-  #       the 'cugraph' / 'wholegraph' repos
   rapids-mamba-retry install \
     --channel "${CPP_CHANNEL}" \
     --channel "${PYTHON_CHANNEL}" \
@@ -74,8 +71,8 @@ if [[ "${RUNNER_ARCH}" != "ARM64" ]]; then
     --channel conda-forge \
     --channel "${DGL_CHANNEL}" \
     --channel nvidia \
-    "pylibwholegraph=${RAPIDS_VERSION},>=24.12.00a1000" \
-    "cugraph-dgl=${RAPIDS_VERSION},>=24.12.00a1000" \
+    "pylibwholegraph=${RAPIDS_VERSION}" \
+    "cugraph-dgl=${RAPIDS_VERSION}" \
     'pytorch::pytorch>=2.3,<2.4' \
     "ogb"
 
@@ -108,15 +105,12 @@ if [[ "${RUNNER_ARCH}" != "ARM64" ]]; then
   conda activate test_cugraph_pyg
   set -u
 
-  # TODO: remove the '>=24.12.00a1000' once we start publishing nightly packages
-  #       from the 'cugraph-gnn' repo and stop publishing them from
-  #       the 'cugraph' / 'wholegraph' repos
   rapids-mamba-retry install \
     --channel "${CPP_CHANNEL}" \
     --channel "${PYTHON_CHANNEL}" \
     --channel pytorch \
-    "pylibwholegraph=${RAPIDS_VERSION},>=24.12.00a1000" \
-    "cugraph-pyg=${RAPIDS_VERSION},>=24.12.00a1000" \
+    "pylibwholegraph=${RAPIDS_VERSION}" \
+    "cugraph-pyg=${RAPIDS_VERSION}" \
     'pytorch::pytorch>=2.3,<2.4' \
     'ogb'
 
@@ -149,15 +143,12 @@ if [[ "${RUNNER_ARCH}" != "ARM64" ]]; then
   conda activate test_pylibwholegraph
   set -u
 
-  # TODO: remove the '>=24.12.00a1000' once we start publishing nightly packages
-  #       from the 'cugraph-gnn' repo and stop publishing them from
-  #       the 'cugraph' / 'wholegraph' repos
   rapids-mamba-retry install \
     --channel "${CPP_CHANNEL}" \
     --channel "${PYTHON_CHANNEL}" \
     --channel pytorch \
     'mkl<2024.1.0' \
-    "pylibwholegraph=${RAPIDS_VERSION},>=24.12.00a1000" \
+    "pylibwholegraph=${RAPIDS_VERSION}" \
     'pytorch::pytorch>=2.3,<2.4' \
     'pytest-forked' \
     'ogb'


### PR DESCRIPTION
Within this release, packages here moved from https://github.com/rapidsai/cugraph and https://github.com/rapidsai/wholegraph to this repo.

To avoid conflicts between nightlies produced from the different sources, CI scripts here were hard-coding the version for CI artifacts to `24.12.00a1000`. That should be removed now that this is the only repo packages are being published from (should have been removed in #66 , sorry for missing it).