### PR TITLE
skip conda-python-tests on arm64

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -104,6 +104,7 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       build_type: pull-request
+      matrix_filter: map(select(.ARCH == "amd64"))
   wheel-build-pylibwholegraph:
     needs: checks
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,7 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
+      matrix_filter: map(select(.ARCH == "amd64"))
   wheel-tests-pylibwholegraph:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.02


### PR DESCRIPTION
All of this repo's `conda-python-tests` jobs have conditions in them like "skip on ARM":

https://github.com/rapidsai/cugraph-gnn/blob/2dd300122dfd6fdea70c9d20c276a3c5946b7613/ci/test_python.sh#L100

https://github.com/rapidsai/cugraph-gnn/blob/2dd300122dfd6fdea70c9d20c276a3c5946b7613/ci/test_python.sh#L141

https://github.com/rapidsai/cugraph-gnn/blob/2dd300122dfd6fdea70c9d20c276a3c5946b7613/ci/test_python.sh#L183

As a result, right now the arm64 `conda-python-tests` jobs are just wasting CI resources... they're spending ~40+~ 5-10 minutes occupying a GPU runner just to download some datasets and then exit ([example build link](https://github.com/rapidsai/cugraph-gnn/actions/runs/11858773988/job/33056063652?pr=69)).

This proposes never even starting those jobs, to make CI here less expensive.

## Notes for Reviewers

### But why are we skipping arm at all?

Lack of pytorch packages. See https://github.com/rapidsai/cugraph-gnn/pull/61#discussion_r1822773547
