### PR TITLE
[Bugfix] Dynamic load NVML symbols for better compatibility

### DIFF
--- a/cpp/src/nvml_wrap.cpp
+++ b/cpp/src/nvml_wrap.cpp
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#if CUDA_VERSION >= 12030
 
 #include "nvml_wrap.h"
 #include <dlfcn.h>
@@ -73,3 +74,5 @@ bool NvmlFabricSymbolLoaded()
   }
   return nvml_loaded;
 }
+
+#endif  // CUDA_VERSION >= 12030

--- a/cpp/src/nvml_wrap.cpp
+++ b/cpp/src/nvml_wrap.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nvml_wrap.h"
+#include <dlfcn.h>
+#include <mutex>
+#include <stdio.h>
+
+namespace {
+
+void* nvml_handle = nullptr;
+std::mutex nvml_mutex;
+bool nvml_loaded = false;
+
+bool LoadNvmlLibrary()
+{
+  nvml_handle = dlopen("libnvidia-ml.so.1", RTLD_NOW);
+  if (!nvml_handle) {
+    nvml_handle = dlopen("libnvidia-ml.so", RTLD_NOW);
+    if (!nvml_handle) {
+      fprintf(stderr, "Failed to load NVML library: %s\n", dlerror());
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename T>
+T LoadNvmlSymbol(const char* name)
+{
+  void* symbol = dlsym(nvml_handle, name);
+  if (!symbol) { return nullptr; }
+  return reinterpret_cast<T>(symbol);
+}
+
+}  // namespace
+
+// Global function pointers
+nvmlDeviceGetHandleByIndexFunc nvmlDeviceGetHandleByIndexPtr = nullptr;
+nvmlDeviceGetGpuFabricInfoFunc nvmlDeviceGetGpuFabricInfoPtr = nullptr;
+
+// Ensure NVML is loaded and symbols are initialized
+bool NvmlFabricSymbolLoaded()
+{
+  std::lock_guard<std::mutex> lock(nvml_mutex);
+  if (nvml_loaded) {
+    return true;  // Already loaded
+  }
+
+  if (LoadNvmlLibrary()) {
+    nvmlDeviceGetHandleByIndexPtr =
+      LoadNvmlSymbol<nvmlDeviceGetHandleByIndexFunc>("nvmlDeviceGetHandleByIndex");
+    nvmlDeviceGetGpuFabricInfoPtr =
+      LoadNvmlSymbol<nvmlDeviceGetGpuFabricInfoFunc>("nvmlDeviceGetGpuFabricInfo");
+
+    if (!nvmlDeviceGetHandleByIndexPtr || !nvmlDeviceGetGpuFabricInfoPtr) {
+      dlclose(nvml_handle);
+      nvml_handle = nullptr;
+    } else {
+      nvml_loaded = true;
+    }
+  }
+  return nvml_loaded;
+}

--- a/cpp/src/nvml_wrap.cpp
+++ b/cpp/src/nvml_wrap.cpp
@@ -11,9 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#if CUDA_VERSION >= 12030
-
 #include "nvml_wrap.h"
+
+#if CUDA_VERSION >= 12030
 #include <dlfcn.h>
 #include <mutex>
 #include <stdio.h>
@@ -74,5 +74,4 @@ bool NvmlFabricSymbolLoaded()
   }
   return nvml_loaded;
 }
-
 #endif  // CUDA_VERSION >= 12030

--- a/cpp/src/nvml_wrap.h
+++ b/cpp/src/nvml_wrap.h
@@ -11,10 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#if CUDA_VERSION >= 12030
-
 #pragma once
+#include <cuda.h>
 
+#if CUDA_VERSION >= 12030
 #include <nvml.h>
 
 bool NvmlFabricSymbolLoaded();
@@ -24,5 +24,4 @@ typedef nvmlReturn_t (*nvmlDeviceGetGpuFabricInfoFunc)(nvmlDevice_t, nvmlGpuFabr
 
 extern nvmlDeviceGetHandleByIndexFunc nvmlDeviceGetHandleByIndexPtr;
 extern nvmlDeviceGetGpuFabricInfoFunc nvmlDeviceGetGpuFabricInfoPtr;
-
 #endif  // CUDA_VERSION >= 12030

--- a/cpp/src/nvml_wrap.h
+++ b/cpp/src/nvml_wrap.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <nvml.h>
+
+bool NvmlFabricSymbolLoaded();
+
+typedef nvmlReturn_t (*nvmlDeviceGetHandleByIndexFunc)(unsigned int, nvmlDevice_t*);
+typedef nvmlReturn_t (*nvmlDeviceGetGpuFabricInfoFunc)(nvmlDevice_t, nvmlGpuFabricInfo_t*);
+
+extern nvmlDeviceGetHandleByIndexFunc nvmlDeviceGetHandleByIndexPtr;
+extern nvmlDeviceGetGpuFabricInfoFunc nvmlDeviceGetGpuFabricInfoPtr;

--- a/cpp/src/nvml_wrap.h
+++ b/cpp/src/nvml_wrap.h
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#if CUDA_VERSION >= 12030
 
 #pragma once
 
@@ -23,3 +24,5 @@ typedef nvmlReturn_t (*nvmlDeviceGetGpuFabricInfoFunc)(nvmlDevice_t, nvmlGpuFabr
 
 extern nvmlDeviceGetHandleByIndexFunc nvmlDeviceGetHandleByIndexPtr;
 extern nvmlDeviceGetGpuFabricInfoFunc nvmlDeviceGetGpuFabricInfoPtr;
+
+#endif  // CUDA_VERSION >= 12030

--- a/cpp/src/wholememory/system_info.hpp
+++ b/cpp/src/wholememory/system_info.hpp
@@ -18,6 +18,7 @@
 #include "wholememory/wholememory.h"
 
 #if CUDA_VERSION >= 12030
+#include "nvml_wrap.h"
 #include <nvml.h>
 #endif
 bool DevAttrPagebleMemoryAccess();
@@ -37,7 +38,9 @@ bool SupportEGM();
 // bool SupportMNNVLForEGM();
 #if CUDA_VERSION >= 12030
 namespace wholememory {
+
+inline bool nvmlFabricSymbolLoaded = NvmlFabricSymbolLoaded();
 wholememory_error_code_t GetGpuFabricInfo(int dev, nvmlGpuFabricInfo_t* gpuFabricInfo);
-}
+}  // namespace wholememory
 
 #endif


### PR DESCRIPTION
[File PR here for the record]
Dynamically load NVML symbols for querying GPU fabric info to address incompatibility issues with outdated display drivers.