### PR TITLE
fix nightly docs workflow dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
   docs-build:
-    needs: conda-cpp-build
+    needs: cpp-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.02
     with:


### PR DESCRIPTION
The branch build triggered by merging #96 failed immediately.

> The workflow is not valid. .github/workflows/build.yaml (Line: 47, Col: 12): Job 'docs-build' depends on unknown job 'conda-cpp-build'.

([build link](https://github.com/rapidsai/cugraph-gnn/actions/runs/12379736454))

This fixes that.