### PR TITLE
simplify wholegraph CMake, other small building and testing changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 exclude: '^thirdparty'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: debug-statements
@@ -54,7 +54,7 @@ repos:
               setup[.]cfg$
       - id: verify-alpha-spec
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.16.0
+    rev: v1.17.0
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -13,13 +13,11 @@ export CMAKE_GENERATOR=Ninja
 
 rapids-print-env
 
-version=$(rapids-generate-version)
-
 rapids-logger "Begin cpp build"
 
 sccache --zero-stats
 
-RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry mambabuild conda/recipes/libwholegraph
+RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry mambabuild conda/recipes/libwholegraph
 
 sccache --show-adv-stats
 

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -7,6 +7,7 @@ rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
 RAPIDS_VERSION="$(rapids-version)"
+export RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -72,8 +72,6 @@ for DEP in "${DEPENDENCIES[@]}"; do
     sed_runner "/\"${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*\"/g" "${FILE}"
   done
 done
-
-sed_runner "s/\(PROJECT_NUMBER[[:space:]]*\)=.*/\1= ${NEXT_SHORT_TAG}/" cpp/Doxyfile
 
 # CI files
 for FILE in .github/workflows/*.yaml; do

--- a/conda/recipes/pylibwholegraph/meta.yaml
+++ b/conda/recipes/pylibwholegraph/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set minor_version = version.split('.')[0] + '.' + version.split('.')[1] %}
@@ -60,7 +60,7 @@ requirements:
     {% if cuda_major == "11" %}
     - cudatoolkit
     {% endif %}
-    - cython
+    - cython >=3.0.0
     - libwholegraph ={{ version }}
     - python
     - rapids-build-backend >=0.3.0,<0.4.0.dev0

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,9 @@
 # limitations under the License.
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
 include(../rapids_config.cmake)
-
-set(WHOLEGRAPH_VERSION "${RAPIDS_VERSION_MAJOR_MINOR}.00")
-
-include(FetchContent)
-
-FetchContent_Declare(
-  rapids-cmake
-  GIT_REPOSITORY https://github.com/rapidsai/rapids-cmake.git
-  GIT_TAG        origin/branch-${RAPIDS_VERSION_MAJOR_MINOR}
-)
-FetchContent_MakeAvailable(rapids-cmake)
 include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-cuda)
@@ -36,13 +25,11 @@ include(rapids-find)
 
 rapids_cuda_init_architectures(WHOLEGRAPH)
 
-project(WHOLEGRAPH VERSION ${WHOLEGRAPH_VERSION} LANGUAGES CXX CUDA)
-
-set(CMAKE_CXX_STANDARD 17)
-
-set(CMAKE_C_USE_RESPONSE_FILE_FOR_INCLUDES   FALSE)
-set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES   FALSE)
-set(CMAKE_CUDA_USE_RESPONSE_FILE_FOR_INCLUDES   FALSE)
+project(
+  WHOLEGRAPH
+  VERSION "${RAPIDS_VERSION}"
+  LANGUAGES CXX CUDA
+)
 
 # Write the version header
 rapids_cmake_write_version_file(include/wholegraph/version_config.hpp)
@@ -109,11 +96,6 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
 
 message("-- Building for GPU_ARCHS = ${CMAKE_CUDA_ARCHITECTURES}")
 
-#list(APPEND WHOLEGRAPH_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr)
-#list(APPEND WHOLEGRAPH_CUDA_FLAGS -Werror=cross-execution-space-call -Wno-deprecated-declarations -Xptxas=--disable-warnings)
-#list(APPEND WHOLEGRAPH_CUDA_FLAGS -Xcompiler=-Wall,-Wno-error=sign-compare,-Wno-error=unused-but-set-variable)
-#list(APPEND WHOLEGRAPH_CUDA_FLAGS -Xfatbin=-compress-all)
-
 # Option to enable line info in CUDA device compilation to allow introspection when profiling /
 # memchecking
 if (CMAKE_CUDA_LINEINFO)
@@ -170,8 +152,6 @@ target_compile_options(wholegraph
             PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${WHOLEGRAPH_CXX_FLAGS}>"
                     "$<$<COMPILE_LANGUAGE:CUDA>:${WHOLEGRAPH_CUDA_FLAGS}>"
 )
-
-#target_link_libraries(wholegraph PRIVATE -static-libgcc -static-libstdc++)
 
 ################################################################################
 # - include paths --------------------------------------------------------------

--- a/cpp/Doxyfile
+++ b/cpp/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "WholeGraph C API"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 25.02
+PROJECT_NUMBER         = $(RAPIDS_VERSION_MAJOR_MINOR)
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/python/pylibwholegraph/CMakeLists.txt
+++ b/python/pylibwholegraph/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,23 +17,17 @@
 cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
 include(../../rapids_config.cmake)
-set(WHOLEGRAPH_VERSION "${RAPIDS_VERSION_MAJOR_MINOR}.00")
-
-include(FetchContent)
-
-FetchContent_Declare(
-        rapids-cmake
-        GIT_REPOSITORY https://github.com/rapidsai/rapids-cmake.git
-        GIT_TAG        origin/branch-${RAPIDS_VERSION_MAJOR_MINOR}
-)
-FetchContent_MakeAvailable(rapids-cmake)
 include(rapids-cmake)
 include(rapids-cuda)
 include(rapids-cpm)
 
 rapids_cuda_init_architectures(PYLIBWHOLEGRAPH)
 
-project(PYLIBWHOLEGRAPH VERSION ${WHOLEGRAPH_VERSION} LANGUAGES CXX CUDA)
+project(
+  PYLIBWHOLEGRAPH
+  VERSION "${RAPIDS_VERSION}"
+  LANGUAGES CXX CUDA
+)
 
 ##############################################################################
 # - User Options  ------------------------------------------------------------
@@ -122,12 +116,6 @@ else()
             "cmake prefix ${CMAKE_PREFIX_PATH} or user dir $ENV{LIBWHOLEGRAPH_DIR}")
 endif()
 
-execute_process(
-        COMMAND "${Python_EXECUTABLE}" -c "import os; import skbuild; print(os.path.join(os.path.dirname(skbuild.__file__), 'resources/cmake'))"
-        OUTPUT_VARIABLE SKBUILD_CMAKE_MODULE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-list(APPEND CMAKE_MODULE_PATH "${SKBUILD_CMAKE_MODULE_PATH}")
-
 include(rapids-cython-core)
 rapids_cython_init()
 
@@ -142,15 +130,11 @@ message(VERBOSE "PYLIBWHOLEGRAPH: Enable detection of conda environment for depe
 # this is needed for clang-tidy runs
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-list(APPEND CXX_DEFINITIONS WHOLEGRAPH_VERSION=${WHOLEGRAPH_VERSION})
-
 message(STATUS "PYLIBWHOLEGRAPH: DEFAULT_CXX_FLAGS='${DEFAULT_CXX_FLAGS}'")
 message(STATUS "PYLIBWHOLEGRAPH: CXX_FLAGS='${CXX_FLAGS}'")
 message(STATUS "PYLIBWHOLEGRAPH: CXX_DEFINITIONS='${CXX_DEFINITIONS}'")
 
 ##############################################################################
-# - Variables ----------------------------------------------------------------
-
-set(WHOLEGRAPH_CPP_TARGET "wholegraph::wholegraph" CACHE STRING "libwholegraph target name")
+# - Cython modules -----------------------------------------------------------
 
 add_subdirectory(pylibwholegraph/binding)


### PR DESCRIPTION
Proposes some miscellaneous packaging cleanup:

* sets minimum CMake version to 3.26.4 everywhere, to match the rest of RAPIDS
* removes commented-out CMake code
* removes unnecessary variables throughout CMake code
  - *including consolidating version references to use `RAPIDS_VERSION` from https://github.com/rapidsai/cugraph-gnn/blob/af22a1271251dc6b02d91cd593ac32b504356b8d/rapids_config.cmake#L20*
* updates some `pre-commit` hooks to their latest versions
