### PR TITLE
Remove invalid conditional

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,6 @@ jobs:
   conda-notebook-tests:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.02
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_notebooks
     with:
       build_type: pull-request
       node_type: "gpu-v100-latest-1"


### PR DESCRIPTION
The nightly tests have been failing despite all runs succeeding because the workflow's logic for filtering out notebook runs is invalid. Examples: https://github.com/rapidsai/cugraph-gnn/actions/runs/12649473784, https://github.com/rapidsai/cugraph-gnn/actions/runs/12609514484. Hopefully this change is sufficient to get the nightly suite passing.