### PR TITLE
enforce `cmake-format` and `cmake-lint`, other small packaging changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,6 +83,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: cugraph-dgl
+      package-type: python
   wheel-build-cugraph-pyg:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.02
@@ -102,6 +103,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: cugraph-pyg
+      package-type: python
   wheel-build-pylibwholegraph:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.02
@@ -121,3 +123,4 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: pylibwholegraph
+      package-type: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,29 @@ repos:
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]
+  - repo: local
+    hooks:
+        - id: cmake-format
+          name: cmake-format
+          entry: ./cpp/scripts/run-cmake-format.sh cmake-format
+          language: python
+          types: [cmake]
+          #exclude: .*/thirdparty/.*
+          # Note that pre-commit autoupdate does not update the versions
+          # of dependencies, so we'll have to update this manually.
+          additional_dependencies:
+            - cmakelang==0.6.13
+          verbose: true
+          require_serial: true
+        - id: cmake-lint
+          name: cmake-lint
+          entry: ./cpp/scripts/run-cmake-format.sh cmake-lint
+          language: python
+          types: [cmake]
+          #exclude: .*/thirdparty/.*
+          # Note that pre-commit autoupdate does not update the versions
+          # of dependencies, so we'll have to update this manually.
+          additional_dependencies:
+            - cmakelang==0.6.13
+          verbose: true
+          require_serial: true

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -56,5 +56,5 @@ else
         -w final_dist \
         dist/*
 
-    RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 final_dist
+    RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python final_dist
 fi

--- a/ci/build_wheel_pylibwholegraph.sh
+++ b/ci/build_wheel_pylibwholegraph.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
 package_dir="python/pylibwholegraph"
 
-export SKBUILD_CMAKE_ARGS="-DDETECT_CONDA_ENV=OFF;-DBUILD_SHARED_LIBS=OFF;-DCMAKE_MESSAGE_LOG_LEVEL=VERBOSE;-DCUDA_STATIC_RUNTIME=ON;-DWHOLEGRAPH_BUILD_WHEELS=ON"
+export SKBUILD_CMAKE_ARGS="-DBUILD_SHARED_LIBS=OFF;-DCMAKE_MESSAGE_LOG_LEVEL=VERBOSE;-DCUDA_STATIC_RUNTIME=ON;-DWHOLEGRAPH_BUILD_WHEELS=ON"
 
 ./ci/build_wheel.sh pylibwholegraph ${package_dir}
 ./ci/validate_wheel.sh ${package_dir} final_dist

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -13,6 +13,13 @@ rapids-dependency-file-generator \
 
 rapids-mamba-retry env create --yes -f env.yaml -n checks
 conda activate checks
+
+# get config for cmake-format checks
+RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
+FORMAT_FILE_URL="https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_VERSION_MAJOR_MINOR}/cmake-format-rapids-cmake.json"
+export RAPIDS_CMAKE_FORMAT_FILE=/tmp/rapids_cmake_ci/cmake-formats-rapids-cmake.json
+mkdir -p $(dirname ${RAPIDS_CMAKE_FORMAT_FILE})
+wget -O ${RAPIDS_CMAKE_FORMAT_FILE} ${FORMAT_FILE_URL}
 
 # Run pre-commit checks
 pre-commit run --hook-stage manual --all-files --show-diff-on-failure

--- a/ci/test_wheel_cugraph-dgl.sh
+++ b/ci/test_wheel_cugraph-dgl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -eoxu pipefail
 
@@ -9,8 +9,8 @@ mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 # Download the pylibwholegraph and cugraph-dgl built in the previous step
-RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./local-deps
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-s3 ./dist
+RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./local-deps
+RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-s3 python ./dist
 
 # determine pytorch and DGL sources
 PKG_CUDA_VER="$(echo ${CUDA_VERSION} | cut -d '.' -f1,2 | tr -d '.')"

--- a/ci/test_wheel_cugraph-pyg.sh
+++ b/ci/test_wheel_cugraph-pyg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -eoxu pipefail
 
@@ -9,8 +9,8 @@ mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 # Download the pylibwholegraph and cugraph-pyg built in the previous step
-RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./local-deps
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-s3 ./dist
+RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./local-deps
+RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-s3 python ./dist
 
 # determine pytorch and pyg sources
 if [[ "${CUDA_VERSION}" == "11.8.0" ]]; then

--- a/ci/test_wheel_pylibwholegraph.sh
+++ b/ci/test_wheel_pylibwholegraph.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -e          # abort the script on error
 set -o pipefail # piped commands propagate their error
@@ -7,7 +7,7 @@ set -E          # ERR traps are inherited by subcommands
 
 mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
-RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
+RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./dist
 
 # determine pytorch source
 PKG_CUDA_VER="$(echo ${CUDA_VERSION} | cut -d '.' -f1,2 | tr -d '.')"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,18 +1,16 @@
-#=============================================================================
+# =============================================================================
 # Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#=============================================================================
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
 
 cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
@@ -34,27 +32,30 @@ project(
 # Write the version header
 rapids_cmake_write_version_file(include/wholegraph/version_config.hpp)
 
-##############################################################################
-# - User Options  ------------------------------------------------------------
+# ##################################################################################################
+# * User Options  ------------------------------------------------------------
 option(BUILD_SHARED_LIBS "Build libwholegraph shared libraries" ON)
-option(CMAKE_CUDA_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler" OFF)
+option(CMAKE_CUDA_LINEINFO
+       "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler" OFF
+)
 option(BUILD_TESTS "Configure CMake to build tests" ON)
 option(CUDA_STATIC_RUNTIME "Statically link the CUDA toolkit runtime and libraries" OFF)
 option(BUILD_WITH_NVSHMEM "Enable nvshmem integration" OFF)
-option(WHOLEGRAPH_EXCLUDE_NVSHMEM_FROM_ALL "Exclude nvshmem targets from wholeGraph's 'all' target" ON)
+option(WHOLEGRAPH_EXCLUDE_NVSHMEM_FROM_ALL "Exclude nvshmem targets from wholeGraph's 'all' target"
+       ON
+)
 option(BUILD_BENCHMARKS "Configure CMake to build benchmark" ON)
 
-##############################################################################
-# - Set options based on user defined one  -----------------------------------
+# ##################################################################################################
+# * Set options based on user defined one  -----------------------------------
 set(_ctk_static_suffix "")
 if(CUDA_STATIC_RUNTIME)
   set(_ctk_static_suffix "_static")
 endif()
 
-##############################################################################
-# - Base rapids options ------------------------------------------------------
-# default build type
-#rapids_cmake_build_type(Release)
+# ##################################################################################################
+# * Base rapids options ------------------------------------------------------ default build type
+#   rapids_cmake_build_type(Release)
 rapids_cmake_build_type(RelWithDebInfo)
 
 # CUDA runtime
@@ -63,23 +64,24 @@ rapids_cuda_init_runtime(USE_STATIC ${CUDA_STATIC_RUNTIME})
 message("CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
 
 if(DETECT_CONDA_ENV)
-  rapids_cmake_support_conda_env( conda_env MODIFY_PREFIX_PATH )
-  if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND DEFINED ENV{CONDA_PREFIX})
-      message(STATUS "No CMAKE_INSTALL_PREFIX argument detected, setting to: $ENV{CONDA_PREFIX}")
-      set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
+  rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
+  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND DEFINED ENV{CONDA_PREFIX})
+    message(STATUS "No CMAKE_INSTALL_PREFIX argument detected, setting to: $ENV{CONDA_PREFIX}")
+    set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
   endif()
 endif()
 
-################################################################################
-# - compiler options -----------------------------------------------------------
+# ##################################################################################################
+# * compiler options -----------------------------------------------------------
 
 # * find CUDAToolkit package
 # * determine GPU architectures
 # * enable the CMake CUDA language
 # * set other CUDA compilation flags
-rapids_find_package(CUDAToolkit REQUIRED
-  BUILD_EXPORT_SET    wholegraph-exports
-  INSTALL_EXPORT_SET  wholegraph-exports
+rapids_find_package(
+  CUDAToolkit REQUIRED
+  BUILD_EXPORT_SET wholegraph-exports
+  INSTALL_EXPORT_SET wholegraph-exports
 )
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -88,26 +90,25 @@ set(WHOLEGRAPH_CXX_FLAGS "")
 set(WHOLEGRAPH_CUDA_FLAGS "")
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    list(APPEND WHOLEGRAPH_CXX_FLAGS -Werror -Wno-error=deprecated-declarations)
+  list(APPEND WHOLEGRAPH_CXX_FLAGS -Werror -Wno-error=deprecated-declarations)
 endif(CMAKE_COMPILER_IS_GNUCXX)
-
 
 message("-- Building for GPU_ARCHS = ${CMAKE_CUDA_ARCHITECTURES}")
 
 # Option to enable line info in CUDA device compilation to allow introspection when profiling /
 # memchecking
-if (CMAKE_CUDA_LINEINFO)
-    list(APPEND WHOLEGRAPH_CUDA_FLAGS -lineinfo)
+if(CMAKE_CUDA_LINEINFO)
+  list(APPEND WHOLEGRAPH_CUDA_FLAGS -lineinfo)
 endif()
 
 # Debug options
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-    message(STATUS "Building with debugging flags")
-    list(APPEND WHOLEGRAPH_CUDA_FLAGS -G -Xcompiler=-rdynamic)
+  message(STATUS "Building with debugging flags")
+  list(APPEND WHOLEGRAPH_CUDA_FLAGS -G -Xcompiler=-rdynamic)
 endif()
 
-################################################################################
-# - find CPM based dependencies  -----------------------------------------------
+# ##################################################################################################
+# * find CPM based dependencies  -----------------------------------------------
 
 rapids_cpm_init()
 
@@ -117,192 +118,189 @@ if(BUILD_WITH_NVSHMEM)
   include(./cmake/thirdparty/get_nvshmem.cmake)
 endif()
 
-
-file(GLOB WHOLEGRAPH_SOURCES
-        "src/*.cpp"
-        "src/wholememory/*.cpp"
-        "src/wholememory_ops/*.cpp"
-        "src/wholememory_ops/*.cu"
-        "src/wholememory_ops/functions/*.cu"
-        "src/wholegraph_ops/*.cpp"
-        "src/wholegraph_ops/*.cu"
-        "src/graph_ops/*.cu"
-        "src/graph_ops/*.cpp")
+file(
+  GLOB
+  WHOLEGRAPH_SOURCES
+  "src/*.cpp"
+  "src/wholememory/*.cpp"
+  "src/wholememory_ops/*.cpp"
+  "src/wholememory_ops/*.cu"
+  "src/wholememory_ops/functions/*.cu"
+  "src/wholegraph_ops/*.cpp"
+  "src/wholegraph_ops/*.cu"
+  "src/graph_ops/*.cu"
+  "src/graph_ops/*.cpp"
+)
 
 add_library(wholegraph)
 add_library(wholegraph::wholegraph ALIAS wholegraph)
 
 target_sources(wholegraph PRIVATE ${WHOLEGRAPH_SOURCES})
 
-set_target_properties(wholegraph
-        PROPERTIES BUILD_RPATH "\$ORIGIN"
-        INSTALL_RPATH "\$ORIGIN"
-        # set target compile options
-        CXX_STANDARD 17
-        CXX_STANDARD_REQUIRED ON
-        CUDA_STANDARD 17
-        CUDA_STANDARD_REQUIRED ON
-        POSITION_INDEPENDENT_CODE ON
-        INTERFACE_POSITION_INDEPENDENT_CODE ON
-        )
-
-target_compile_options(wholegraph
-            PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${WHOLEGRAPH_CXX_FLAGS}>"
-                    "$<$<COMPILE_LANGUAGE:CUDA>:${WHOLEGRAPH_CUDA_FLAGS}>"
+set_target_properties(
+  wholegraph
+  PROPERTIES BUILD_RPATH "\$ORIGIN"
+             INSTALL_RPATH "\$ORIGIN"
+             # set target compile options
+             CXX_STANDARD 17
+             CXX_STANDARD_REQUIRED ON
+             CUDA_STANDARD 17
+             CUDA_STANDARD_REQUIRED ON
+             POSITION_INDEPENDENT_CODE ON
+             INTERFACE_POSITION_INDEPENDENT_CODE ON
 )
 
-################################################################################
-# - include paths --------------------------------------------------------------
-
-set(WHOLEGRAPH_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include CACHE STRING
-        "Path to wholegraph include directory")
-
-target_include_directories(wholegraph
-    PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/src"
-    PUBLIC
-        "$<BUILD_INTERFACE:${NCCL_INCLUDE_DIR}>"
-        "$<BUILD_INTERFACE:${WHOLEGRAPH_INCLUDE_DIR}>"
-        "$<INSTALL_INTERFACE:include>"
+target_compile_options(
+  wholegraph PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${WHOLEGRAPH_CXX_FLAGS}>"
+                     "$<$<COMPILE_LANGUAGE:CUDA>:${WHOLEGRAPH_CUDA_FLAGS}>"
 )
 
+# ##################################################################################################
+# * include paths --------------------------------------------------------------
 
-################################################################################
-# - link libraries -------------------------------------------------------------
-target_link_libraries(wholegraph
-PUBLIC
-    CUDA::cuda_driver
-    CUDA::cudart${_ctk_static_suffix}
-    raft::raft
-PRIVATE
-    NCCL::NCCL
+set(WHOLEGRAPH_INCLUDE_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    CACHE STRING "Path to wholegraph include directory"
 )
 
-if (CUDAToolkit_VERSION VERSION_GREATER "12.3")
-    # Link the NVML library if CUDA version is greater than 12.3
-    target_link_libraries(wholegraph PRIVATE CUDA::nvml)
+target_include_directories(
+  wholegraph
+  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src"
+  PUBLIC "$<BUILD_INTERFACE:${NCCL_INCLUDE_DIR}>" "$<BUILD_INTERFACE:${WHOLEGRAPH_INCLUDE_DIR}>"
+         "$<INSTALL_INTERFACE:include>"
+)
+
+# ##################################################################################################
+# * link libraries -------------------------------------------------------------
+target_link_libraries(
+  wholegraph
+  PUBLIC CUDA::cuda_driver CUDA::cudart${_ctk_static_suffix} raft::raft
+  PRIVATE NCCL::NCCL
+)
+
+if(CUDAToolkit_VERSION VERSION_GREATER "12.3")
+  # Link the NVML library if CUDA version is greater than 12.3
+  target_link_libraries(wholegraph PRIVATE CUDA::nvml)
 endif()
 
 if(BUILD_WITH_NVSHMEM)
 
-        file(GLOB_RECURSE NVSHMEM_SOURCE_FILES "src/wholememory_ops/functions/nvshmem*.cu")
-        set_source_files_properties( ${NVSHMEM_SOURCE_FILES}
-        PROPERTIES
-        COMPILE_FLAGS "-rdc=true"
-        )
+  file(GLOB_RECURSE NVSHMEM_SOURCE_FILES "src/wholememory_ops/functions/nvshmem*.cu")
+  set_source_files_properties(${NVSHMEM_SOURCE_FILES} PROPERTIES COMPILE_FLAGS "-rdc=true")
   target_compile_definitions(wholegraph PRIVATE WITH_NVSHMEM_SUPPORT)
   target_link_libraries(wholegraph PRIVATE nvshmem::nvshmem_host nvshmem::nvshmem_device)
 endif()
 
-
 # optionally build tests
 if(BUILD_TESTS AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-	include(${rapids-cmake-dir}/cpm/gtest.cmake)
-	rapids_cpm_gtest(BUILD_STATIC)
-    include(CTest) # calls enable_testing()
+  include(${rapids-cmake-dir}/cpm/gtest.cmake)
+  rapids_cpm_gtest(BUILD_STATIC)
+  include(CTest) # calls enable_testing()
 
-    add_subdirectory(tests)
+  add_subdirectory(tests)
 endif()
 
 if(BUILD_WITH_NVSHMEM)
-        get_target_property(NVSHMEM_BINARY_DIR nvshmem BINARY_DIR)
-        add_library(nvshmem_wholememory_bootstrap SHARED)
-        target_sources(nvshmem_wholememory_bootstrap PRIVATE src/nvshmem_plugins/nvshmem_wholememory_bootstrap.cpp)
-        target_link_libraries(nvshmem_wholememory_bootstrap PRIVATE wholegraph nvshmem::nvshmem_host )
-        target_include_directories(nvshmem_wholememory_bootstrap
-                             PRIVATE
-                             ${CMAKE_CURRENT_SOURCE_DIR}/src
-                             ${NVSHMEM_BINARY_DIR}/include/modules/common
-                             ${NVSHMEM_BINARY_DIR}/include/modules/bootstrap
-                            )
-
+  get_target_property(NVSHMEM_BINARY_DIR nvshmem BINARY_DIR)
+  add_library(nvshmem_wholememory_bootstrap SHARED)
+  target_sources(
+    nvshmem_wholememory_bootstrap PRIVATE src/nvshmem_plugins/nvshmem_wholememory_bootstrap.cpp
+  )
+  target_link_libraries(nvshmem_wholememory_bootstrap PRIVATE wholegraph nvshmem::nvshmem_host)
+  target_include_directories(
+    nvshmem_wholememory_bootstrap
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src ${NVSHMEM_BINARY_DIR}/include/modules/common
+            ${NVSHMEM_BINARY_DIR}/include/modules/bootstrap
+  )
 
 endif()
-
 
 # optionally build benchmark
-if (BUILD_BENCHMARKS AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    add_subdirectory(bench)
+if(BUILD_BENCHMARKS AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  add_subdirectory(bench)
 endif()
 
-##############################################################################
-# - install targets ----------------------------------------------------------
+# ##################################################################################################
+# * install targets ----------------------------------------------------------
 
 set(doc_string [=[
-]=])
-set(code_string
-        [=[
-]=])
+]=]
+)
+set(code_string [=[
+]=]
+)
 
 set(WHOLEGRAPH_PUBLIC_HEADERS
-        wholememory/device_reference.cuh
-        wholememory/embedding.h
-        wholememory/env_func_ptrs.h
-        wholememory/global_reference.h
-        wholememory/tensor_description.h
-        wholememory/wholememory.h
-        wholememory/wholememory_tensor.h
-        wholememory/wholememory_op.h
-        wholememory/wholegraph_op.h
-        wholememory/graph_op.h
-        )
+    wholememory/device_reference.cuh
+    wholememory/embedding.h
+    wholememory/env_func_ptrs.h
+    wholememory/global_reference.h
+    wholememory/tensor_description.h
+    wholememory/wholememory.h
+    wholememory/wholememory_tensor.h
+    wholememory/wholememory_op.h
+    wholememory/wholegraph_op.h
+    wholememory/graph_op.h
+)
 
 foreach(file IN LISTS WHOLEGRAPH_PUBLIC_HEADERS)
-    cmake_path(GET file PARENT_PATH file_out_)
-    string(JOIN "/" out_path "include" ${file_out_})
-    install(FILES "${WHOLEGRAPH_INCLUDE_DIR}/${file}"
-            DESTINATION "${out_path}")
+  cmake_path(GET file PARENT_PATH file_out_)
+  string(JOIN "/" out_path "include" ${file_out_})
+  install(FILES "${WHOLEGRAPH_INCLUDE_DIR}/${file}" DESTINATION "${out_path}")
 endforeach()
 
-rapids_cmake_install_lib_dir( lib_dir )
+rapids_cmake_install_lib_dir(lib_dir)
 
-set(PROGRAM_PERMISSIONS_DEFAULT
-        OWNER_WRITE OWNER_READ OWNER_EXECUTE
-        GROUP_READ GROUP_EXECUTE
-        WORLD_READ WORLD_EXECUTE)
+set(PROGRAM_PERMISSIONS_DEFAULT OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
+                                WORLD_READ WORLD_EXECUTE
+)
 
 set(WHOLEGRAPH_INSTALL_LIBS wholegraph)
 if(BUILD_WITH_NVSHMEM)
-        list(APPEND WHOLEGRAPH_INSTALL_LIBS nvshmem_wholememory_bootstrap  nvshmem_host)
+  list(APPEND WHOLEGRAPH_INSTALL_LIBS nvshmem_wholememory_bootstrap nvshmem_host)
 endif()
 
 install(
-        TARGETS     ${WHOLEGRAPH_INSTALL_LIBS}
-        DESTINATION ${lib_dir}
-        PERMISSIONS ${PROGRAM_PERMISSIONS_DEFAULT}
-        EXPORT wholegraph-exports)
+  TARGETS ${WHOLEGRAPH_INSTALL_LIBS}
+  DESTINATION ${lib_dir}
+  PERMISSIONS ${PROGRAM_PERMISSIONS_DEFAULT}
+  EXPORT wholegraph-exports
+)
 
 rapids_export(
-        INSTALL wholegraph
-        EXPORT_SET wholegraph-exports
-        GLOBAL_TARGETS wholegraph
-        NAMESPACE wholegraph::
-        DOCUMENTATION doc_string
-        FINAL_CODE_BLOCK code_string)
+  INSTALL wholegraph
+  EXPORT_SET wholegraph-exports
+  GLOBAL_TARGETS wholegraph
+  NAMESPACE wholegraph::
+  DOCUMENTATION doc_string
+  FINAL_CODE_BLOCK code_string
+)
 
 # build export targets
 rapids_export(
-        BUILD wholegraph
-        EXPORT_SET wholegraph-exports
-        GLOBAL_TARGETS wholegraph
-        NAMESPACE wholegraph::
-        DOCUMENTATION doc_string
-        FINAL_CODE_BLOCK code_string)
+  BUILD wholegraph
+  EXPORT_SET wholegraph-exports
+  GLOBAL_TARGETS wholegraph
+  NAMESPACE wholegraph::
+  DOCUMENTATION doc_string
+  FINAL_CODE_BLOCK code_string
+)
 
-################################################################################
-# - make documentation ---------------------------------------------------------
-# requires doxygen and graphviz to be installed
-# from build directory, run make doxygen
+# ##################################################################################################
+# * make documentation --------------------------------------------------------- requires doxygen
+#   and graphviz to be installed from build directory, run make doxygen
 
-##############################################################################
-# - doxygen docs -------------------------------------------------------------
+# ##################################################################################################
+# * doxygen docs -------------------------------------------------------------
 
 find_package(Doxygen 1.8.11)
 if(Doxygen_FOUND)
-        add_custom_command(OUTPUT WHOLEGRAPH_DOXYGEN
-                           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                           COMMAND doxygen Doxyfile
-                           VERBATIM)
+  add_custom_command(
+    OUTPUT WHOLEGRAPH_DOXYGEN
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND doxygen Doxyfile
+    VERBATIM
+  )
 
-        add_custom_target(doxygen DEPENDS WHOLEGRAPH_DOXYGEN)
+  add_custom_target(doxygen DEPENDS WHOLEGRAPH_DOXYGEN)
 endif()

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -1,72 +1,66 @@
-#=============================================================================
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# =============================================================================
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#=============================================================================
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
 # option(BUILD_BENCHMARKS "Build wholegraph C++ benchmark tests" ON)
 message(VERBOSE "WHOLEGRAPH: Building wholegraph C++ benchmarks: ${BUILD_BENCHMARKS}")
 
 function(ConfigureBench)
 
-    set(options OPTIONAL)
-    set(oneValueArgs NAME)
-    set(multiValueArgs PATH TARGETS CONFIGURATIONS)
-    cmake_parse_arguments(ConfigureBench "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  set(options OPTIONAL)
+  set(oneValueArgs NAME)
+  set(multiValueArgs PATH TARGETS CONFIGURATIONS)
+  cmake_parse_arguments(ConfigureBench "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    set(BENCH_NAME ${ConfigureBench_NAME})
+  set(BENCH_NAME ${ConfigureBench_NAME})
 
-    add_executable(${BENCH_NAME} ${ConfigureBench_PATH})
+  add_executable(${BENCH_NAME} ${ConfigureBench_PATH})
 
-    target_include_directories(${BENCH_NAME} PRIVATE "$<BUILD_INTERFACE:${WHOLEGRAPH_SOURCE_DIR}>/src")
-    target_link_libraries(
-            ${BENCH_NAME}
-            PRIVATE wholegraph
-            raft::raft
-            rmm::rmm
-            pthread
-    )
-    if(BUILD_WITH_NVSHMEM)
-        target_compile_definitions(${BENCH_NAME} PRIVATE WITH_NVSHMEM_SUPPORT)
-    endif()
-    set_target_properties(
-            ${BENCH_NAME}
-            PROPERTIES # set target compile options
-            INSTALL_RPATH "\$ORIGIN/../../../lib"
-            CXX_STANDARD 17
-            CXX_STANDARD_REQUIRED ON
-            CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}"
-            POSITION_INDEPENDENT_CODE ON
-            RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${WHOLEGRAPH_BINARY_DIR}/gbench>"
-            INTERFACE_POSITION_INDEPENDENT_CODE ON
-    )
-    target_compile_options(${BENCH_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror
-            -Wno-error=deprecated-declarations>)
+  target_include_directories(
+    ${BENCH_NAME} PRIVATE "$<BUILD_INTERFACE:${WHOLEGRAPH_SOURCE_DIR}>/src"
+  )
+  target_link_libraries(${BENCH_NAME} PRIVATE wholegraph raft::raft rmm::rmm pthread)
+  if(BUILD_WITH_NVSHMEM)
+    target_compile_definitions(${BENCH_NAME} PRIVATE WITH_NVSHMEM_SUPPORT)
+  endif()
+  set_target_properties(
+    ${BENCH_NAME}
+    PROPERTIES # set target compile options
+               INSTALL_RPATH "\$ORIGIN/../../../lib"
+               CXX_STANDARD 17
+               CXX_STANDARD_REQUIRED ON
+               CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}"
+               POSITION_INDEPENDENT_CODE ON
+               RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${WHOLEGRAPH_BINARY_DIR}/gbench>"
+               INTERFACE_POSITION_INDEPENDENT_CODE ON
+  )
+  target_compile_options(
+    ${BENCH_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror
+                         -Wno-error=deprecated-declarations>
+  )
 
-    install(
-            TARGETS ${BENCH_NAME}
-            COMPONENT testing
-            DESTINATION bin/gbench/libwholegraph
-            EXCLUDE_FROM_ALL
-    )
-
+  install(
+    TARGETS ${BENCH_NAME}
+    COMPONENT testing
+    DESTINATION bin/gbench/libwholegraph
+    EXCLUDE_FROM_ALL
+  )
 
 endfunction()
 
 if(BUILD_BENCHMARKS)
-    ConfigureBench(
-            NAME GATHER_SCATTER_BENCH
-            PATH wholememory_ops/gather_scatter_bench.cu
-            common/wholegraph_benchmark.cpp
-    )
+  ConfigureBench(
+    NAME GATHER_SCATTER_BENCH PATH wholememory_ops/gather_scatter_bench.cu
+    common/wholegraph_benchmark.cpp
+  )
 
 endif()

--- a/cpp/cmake/config.json
+++ b/cpp/cmake/config.json
@@ -1,0 +1,39 @@
+{
+    "parse": {
+        "additional_commands": {
+            "CPMFindPackage": {
+                "kwargs": {
+                    "NAME": 1,
+                    "GITHUB_REPOSITORY": "?",
+                    "GIT_TAG": "?",
+                    "VERSION": "?",
+                    "GIT_SHALLOW": "?",
+                    "OPTIONS": "*",
+                    "FIND_PACKAGE_ARGUMENTS": "*"
+                }
+            }
+        }
+    },
+    "format": {
+        "line_width": 100,
+        "tab_size": 2,
+        "command_case": "unchanged",
+        "max_lines_hwrap": 1,
+        "max_pargs_hwrap": 999,
+        "dangle_parens": true
+    },
+    "lint": {
+        "disabled_codes": [
+            "C0111", "C0113", "C0301"
+        ],
+        "function_pattern": "[0-9A-z_]+",
+        "macro_pattern": "[0-9A-z_]+",
+        "global_var_pattern": "[A-z][0-9A-z_]+",
+        "internal_var_pattern": "_[A-z][0-9A-z_]+",
+        "local_var_pattern": "[A-z][A-z0-9_]+",
+        "private_var_pattern": "_[0-9A-z_]+",
+        "public_var_pattern": "[A-z][0-9A-z_]+",
+        "argument_var_pattern": "[A-z][A-z0-9_]+",
+        "keyword_pattern": "[A-z][0-9A-z_]+"
+    }
+}

--- a/cpp/cmake/thirdparty/get_nccl.cmake
+++ b/cpp/cmake/thirdparty/get_nccl.cmake
@@ -1,33 +1,32 @@
-#=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# =============================================================================
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#=============================================================================
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
 
 function(find_and_configure_nccl)
 
-    if(TARGET NCCL::NCCL)
-        return()
-    endif()
+  if(TARGET NCCL::NCCL)
+    return()
+  endif()
 
-    rapids_find_generate_module(NCCL
-        HEADER_NAMES  nccl.h
-        LIBRARY_NAMES nccl
-    )
+  rapids_find_generate_module(
+    NCCL
+    HEADER_NAMES nccl.h
+    LIBRARY_NAMES nccl
+  )
 
-    # Currently NCCL has no CMake build-system so we require
-    # it built and installed on the machine already
-    rapids_find_package(NCCL REQUIRED)
+  # Currently NCCL has no CMake build-system so we require it built and installed on the machine
+  # already
+  rapids_find_package(NCCL REQUIRED)
 
 endfunction()
 

--- a/cpp/cmake/thirdparty/get_nvshmem.cmake
+++ b/cpp/cmake/thirdparty/get_nvshmem.cmake
@@ -1,54 +1,45 @@
-#=============================================================================
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# =============================================================================
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#=============================================================================
-
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
 
 set(USE_NVSHMEM_VERSION 2.10.1)
 set(USE_NVSHMEM_VERSION_BRANCH 3)
 function(find_and_configure_nvshmem)
 
+  set(oneValueArgs VERSION VERSION_BRANCH EXCLUDE_FROM_ALL INSTALL_DIR)
+  cmake_parse_arguments(PKG "" "${oneValueArgs}" "" ${ARGN})
 
-    set(oneValueArgs VERSION VERSION_BRANCH   EXCLUDE_FROM_ALL INSTALL_DIR)
-    cmake_parse_arguments(PKG "" "${oneValueArgs}" "" ${ARGN} )
+  rapids_cpm_find(
+    nvshmem ${PKG_VERSION}
+    GLOBAL_TARGETS nvshmem::nvshmem nvshmem::nvshmem_device nvshmem::nvshmem_host
+    CPM_ARGS
+    EXCLUDE_FROM_ALL
+      ${PKG_EXCLUDE_FROM_ALL}
+      URL
+      https://developer.download.nvidia.cn/compute/redist/nvshmem/${PKG_VERSION}/source/nvshmem_src_${PKG_VERSION}-${PKG_VERSION_BRANCH}.txz
+    OPTIONS "NVSHMEM_IBGDA_SUPPORT ON" "NVSHMEM_IBDEVX_SUPPORT ON" "NVSHMEM_BUILD_EXAMPLES OFF"
+            "NVSHMEM_BUILD_TESTS OFF" "NVSHMEM_PREFIX ${PKG_INSTALL_DIR}"
+  )
 
-    rapids_cpm_find(nvshmem ${PKG_VERSION}
-                    GLOBAL_TARGETS nvshmem::nvshmem nvshmem::nvshmem_device nvshmem::nvshmem_host
-                    CPM_ARGS
-                        EXCLUDE_FROM_ALL ${PKG_EXCLUDE_FROM_ALL}
-                        URL https://developer.download.nvidia.cn/compute/redist/nvshmem/${PKG_VERSION}/source/nvshmem_src_${PKG_VERSION}-${PKG_VERSION_BRANCH}.txz
-                        OPTIONS
-                            "NVSHMEM_IBGDA_SUPPORT ON"
-                            "NVSHMEM_IBDEVX_SUPPORT ON"
-                            "NVSHMEM_BUILD_EXAMPLES OFF"
-                            "NVSHMEM_BUILD_TESTS OFF"
-                            "NVSHMEM_PREFIX ${PKG_INSTALL_DIR}"
-                    )
-
-
-    if(NOT TARGET nvshmem::nvshmem AND TARGET nvshmem)
-        add_library( nvshmem::nvshmem ALIAS nvshmem)
-        add_library(nvshmem::nvshmem_device ALIAS nvshmem_device)
-        add_library(nvshmem::nvshmem_host ALIAS nvshmem_host)
-    endif()
-
+  if(NOT TARGET nvshmem::nvshmem AND TARGET nvshmem)
+    add_library(nvshmem::nvshmem ALIAS nvshmem)
+    add_library(nvshmem::nvshmem_device ALIAS nvshmem_device)
+    add_library(nvshmem::nvshmem_host ALIAS nvshmem_host)
+  endif()
 
 endfunction()
 
-
-find_and_configure_nvshmem(VERSION           ${USE_NVSHMEM_VERSION}
-                           VERSION_BRANCH    ${USE_NVSHMEM_VERSION_BRANCH}
-                           EXCLUDE_FROM_ALL  ${WHOLEGRAPH_EXCLUDE_NVSHMEM_FROM_ALL}
-                           INSTALL_DIR       ${CMAKE_INSTALL_PREFIX}
-                           )
+find_and_configure_nvshmem(
+  VERSION ${USE_NVSHMEM_VERSION} VERSION_BRANCH ${USE_NVSHMEM_VERSION_BRANCH} EXCLUDE_FROM_ALL
+  ${WHOLEGRAPH_EXCLUDE_NVSHMEM_FROM_ALL} INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+)

--- a/cpp/cmake/thirdparty/get_raft.cmake
+++ b/cpp/cmake/thirdparty/get_raft.cmake
@@ -1,67 +1,62 @@
-#=============================================================================
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# =============================================================================
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#=============================================================================
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
 
 set(WHOLEGRAPH_MIN_VERSION_raft "${RAPIDS_VERSION_MAJOR}.${RAPIDS_VERSION_MINOR}.00")
 set(WHOLEGRAPH_BRANCH_VERSION_raft "${RAPIDS_VERSION_MAJOR}.${RAPIDS_VERSION_MINOR}")
 
 function(find_and_configure_raft)
 
-    set(oneValueArgs VERSION FORK PINNED_TAG CLONE_ON_PIN)
-    cmake_parse_arguments(PKG "" "${oneValueArgs}" "" ${ARGN} )
+  set(oneValueArgs VERSION FORK PINNED_TAG CLONE_ON_PIN)
+  cmake_parse_arguments(PKG "" "${oneValueArgs}" "" ${ARGN})
 
-    if(PKG_CLONE_ON_PIN AND NOT PKG_PINNED_TAG STREQUAL "branch-${WHOLEGRAPH_BRANCH_VERSION_raft}")
-        message("Pinned tag found: ${PKG_PINNED_TAG}. Cloning raft locally.")
-        set(CPM_DOWNLOAD_raft ON)
-    endif()
+  if(PKG_CLONE_ON_PIN AND NOT PKG_PINNED_TAG STREQUAL "branch-${WHOLEGRAPH_BRANCH_VERSION_raft}")
+    message("Pinned tag found: ${PKG_PINNED_TAG}. Cloning raft locally.")
+    set(CPM_DOWNLOAD_raft ON)
+  endif()
 
-    rapids_cpm_find(raft ${PKG_VERSION}
-      GLOBAL_TARGETS      raft::raft
-      BUILD_EXPORT_SET    wholegraph-exports
-      INSTALL_EXPORT_SET  wholegraph-exports
-        CPM_ARGS
-            EXCLUDE_FROM_ALL TRUE
-            GIT_REPOSITORY https://github.com/${PKG_FORK}/raft.git
-            GIT_TAG        ${PKG_PINNED_TAG}
-            SOURCE_SUBDIR  cpp
-            OPTIONS
-                "RAFT_COMPILE_LIBRARIES OFF"
-                "RAFT_COMPILE_DIST_LIBRARY OFF"
-                "BUILD_TESTS OFF"
-                "BUILD_BENCH OFF"
-                "BUILD_PRIMS_BENCH OFF"
-                "RAFT_ENABLE_cuco_DEPENDENCY OFF"
-    )
+  rapids_cpm_find(
+    raft ${PKG_VERSION}
+    GLOBAL_TARGETS raft::raft
+    BUILD_EXPORT_SET wholegraph-exports
+    INSTALL_EXPORT_SET wholegraph-exports
+    CPM_ARGS
+    EXCLUDE_FROM_ALL TRUE
+    GIT_REPOSITORY https://github.com/${PKG_FORK}/raft.git
+    GIT_TAG ${PKG_PINNED_TAG} SOURCE_SUBDIR cpp
+    OPTIONS "RAFT_COMPILE_LIBRARIES OFF" "RAFT_COMPILE_DIST_LIBRARY OFF" "BUILD_TESTS OFF"
+            "BUILD_BENCH OFF" "BUILD_PRIMS_BENCH OFF" "RAFT_ENABLE_cuco_DEPENDENCY OFF"
+  )
 
-    if(raft_ADDED)
-        message(VERBOSE "WHOLEGRAPH: Using RAFT located in ${raft_SOURCE_DIR}")
-    else()
-        message(VERBOSE "WHOLEGRAPH: Using RAFT located in ${raft_DIR}")
-    endif()
+  if(raft_ADDED)
+    message(VERBOSE "WHOLEGRAPH: Using RAFT located in ${raft_SOURCE_DIR}")
+  else()
+    message(VERBOSE "WHOLEGRAPH: Using RAFT located in ${raft_DIR}")
+  endif()
 
 endfunction()
 
-# Change pinned tag and fork here to test a commit in CI
-# To use a different RAFT locally, set the CMake variable
-# CPM_raft_SOURCE=/path/to/local/raft
-find_and_configure_raft(VERSION    ${WHOLEGRAPH_MIN_VERSION_raft}
-                        FORK       rapidsai
-                        PINNED_TAG branch-${WHOLEGRAPH_BRANCH_VERSION_raft}
-
-                        # When PINNED_TAG above doesn't match wholegraph,
-                        # force local raft clone in build directory
-                        # even if it's already installed.
-                        CLONE_ON_PIN     ON
+# Change pinned tag and fork here to test a commit in CI To use a different RAFT locally, set the
+# CMake variable CPM_raft_SOURCE=/path/to/local/raft
+find_and_configure_raft(
+  VERSION
+  ${WHOLEGRAPH_MIN_VERSION_raft}
+  FORK
+  rapidsai
+  PINNED_TAG
+  branch-${WHOLEGRAPH_BRANCH_VERSION_raft}
+  # When PINNED_TAG above doesn't match wholegraph, force local raft clone in build directory even
+  # if it's already installed.
+  CLONE_ON_PIN
+  ON
 )

--- a/cpp/scripts/run-cmake-format.sh
+++ b/cpp/scripts/run-cmake-format.sh
@@ -17,7 +17,7 @@
 # and exits gracefully if the file is not found. If a user wishes to specify a
 # config file at a nonstandard location, they may do so by setting the
 # environment variable RAPIDS_CMAKE_FORMAT_FILE.
-# 
+#
 # This script can be invoked directly anywhere within the project repository.
 # Alternatively, it may be invoked as a pre-commit hook via
 # `pre-commit run (cmake-format)|(cmake-lint)`.

--- a/cpp/scripts/run-cmake-format.sh
+++ b/cpp/scripts/run-cmake-format.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+
+# copied from: https://github.com/rapidsai/rapids-cmake/blob/branch-25.02/ci/checks/run-cmake-format.sh
+#
+# This script is a wrapper for cmakelang that may be used with pre-commit. The
+# wrapping is necessary because RAPIDS libraries split configuration for
+# cmakelang linters between a local config file and a second config file that's
+# shared across all of RAPIDS via rapids-cmake. We need a way to invoke CMake linting commands
+# without causing pre-commit failures (which could block local commits or CI),
+# while also being sufficiently flexible to allow users to maintain the config
+# file independently of a build directory.
+#
+# This script provides the minimal functionality to enable those use cases. It
+# searches in a number of predefined locations for the rapids-cmake config file
+# and exits gracefully if the file is not found. If a user wishes to specify a
+# config file at a nonstandard location, they may do so by setting the
+# environment variable RAPIDS_CMAKE_FORMAT_FILE.
+# 
+# This script can be invoked directly anywhere within the project repository.
+# Alternatively, it may be invoked as a pre-commit hook via
+# `pre-commit run (cmake-format)|(cmake-lint)`.
+#
+# Usage:
+# bash run-cmake-format.sh {cmake-format,cmake-lint} infile [infile ...]
+
+status=0
+if [ -z ${CUGRAPH_GNN_ROOT:+PLACEHOLDER} ]; then
+    CUGRAPH_GNN_BUILD_DIR=$(git rev-parse --show-toplevel 2>&1)/cpp/build
+    status=$?
+else
+    CUGRAPH_GNN_BUILD_DIR=${CUGRAPH_GNN_ROOT}
+fi
+
+if ! [ ${status} -eq 0 ]; then
+    if [[ ${CUGRAPH_GNN_BUILD_DIR} == *"not a git repository"* ]]; then
+        echo "This script must be run inside the cugraph-gnn repository, or the CUGRAPH_GNN_ROOT environment variable must be set."
+    else
+        echo "Script failed with unknown error attempting to determine project root:"
+        echo ${CUGRAPH_GNN_BUILD_DIR}
+    fi
+    exit 1
+fi
+
+DEFAULT_FORMAT_FILE_LOCATIONS=(
+  "${CUGRAPH_GNN_BUILD_DIR:-${HOME}}/_deps/rapids-cmake-src/cmake-format-rapids-cmake.json"
+)
+
+if [ -z ${RAPIDS_CMAKE_FORMAT_FILE:+PLACEHOLDER} ]; then
+    for file_path in ${DEFAULT_FORMAT_FILE_LOCATIONS[@]}; do
+        if [ -f ${file_path} ]; then
+            RAPIDS_CMAKE_FORMAT_FILE=${file_path}
+            break
+        fi
+    done
+fi
+
+if [ -z ${RAPIDS_CMAKE_FORMAT_FILE:+PLACEHOLDER} ]; then
+  echo "The rapids-cmake cmake-format configuration file was not found at any of the default search locations: "
+  echo ""
+  ( IFS=$'\n'; echo "${DEFAULT_FORMAT_FILE_LOCATIONS[*]}" )
+  echo ""
+  echo "Try setting the environment variable RAPIDS_CMAKE_FORMAT_FILE to the path to the config file."
+  exit 0
+else
+  echo "Using format file ${RAPIDS_CMAKE_FORMAT_FILE}"
+fi
+
+if [[ $1 == "cmake-format" ]]; then
+  cmake-format -i --config-files cpp/cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- ${@:2}
+elif [[ $1 == "cmake-lint" ]]; then
+  # Since the pre-commit hook is verbose, we have to be careful to only
+  # present cmake-lint's output (which is quite verbose) if we actually
+  # observe a failure.
+  OUTPUT=$(cmake-lint --config-files cpp/cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- ${@:2})
+  status=$?
+
+  if ! [ ${status} -eq 0 ]; then
+    echo "${OUTPUT}"
+  fi
+  exit ${status}
+fi

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,18 +1,16 @@
-#=============================================================================
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# =============================================================================
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#=============================================================================
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
 # Build options
 option(DISABLE_DEPRECATION_WARNING "Disable warnings generated from deprecated declarations." OFF)
 option(CODE_COVERAGE "Enable generating code coverage with gcov." OFF)
@@ -20,73 +18,88 @@ option(CODE_COVERAGE "Enable generating code coverage with gcov." OFF)
 # This function takes in a test name and test source and handles setting all of the associated
 # properties and linking to build the test
 function(ConfigureTestInternal TEST_NAME)
-    add_executable(${TEST_NAME} ${ARGN})
-    target_include_directories(${TEST_NAME} PRIVATE "$<BUILD_INTERFACE:${WHOLEGRAPH_SOURCE_DIR}>/src")
-    target_link_libraries(${TEST_NAME} PRIVATE GTest::gmock GTest::gtest GTest::gmock_main GTest::gtest_main
-            wholegraph raft::raft rmm::rmm pthread)
-    if(BUILD_WITH_NVSHMEM)
-            target_compile_definitions(${TEST_NAME} PRIVATE WITH_NVSHMEM_SUPPORT)
+  add_executable(${TEST_NAME} ${ARGN})
+  target_include_directories(${TEST_NAME} PRIVATE "$<BUILD_INTERFACE:${WHOLEGRAPH_SOURCE_DIR}>/src")
+  target_link_libraries(
+    ${TEST_NAME} PRIVATE GTest::gmock GTest::gtest GTest::gmock_main GTest::gtest_main wholegraph
+                         raft::raft rmm::rmm pthread
+  )
+  if(BUILD_WITH_NVSHMEM)
+    target_compile_definitions(${TEST_NAME} PRIVATE WITH_NVSHMEM_SUPPORT)
+  endif()
+
+  set_target_properties(
+    ${TEST_NAME}
+    PROPERTIES POSITION_INDEPENDENT_CODE ON
+               RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${WHOLEGRAPH_BINARY_DIR}/gtests>"
+               CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}"
+               INSTALL_RPATH "\$ORIGIN/../../../lib"
+  )
+  target_compile_definitions(
+    ${TEST_NAME} PUBLIC "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${WHOLEGRAPH_LOGGING_LEVEL}"
+  )
+  target_compile_options(
+    ${TEST_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror
+                        -Wno-error=deprecated-declarations>
+  )
+
+  if(DISABLE_DEPRECATION_WARNING)
+    target_compile_options(
+      ${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-deprecated-declarations>
+    )
+    target_compile_options(
+      ${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>
+    )
+  endif()
+
+  if(CODE_COVERAGE)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+
+      set(KEEP_DIR ${CMAKE_CURRENT_BINARY_DIR}/tmp)
+      make_directory(${KEEP_DIR})
+      target_compile_options(
+        ${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:--keep --keep-dir=${KEEP_DIR}>
+      )
+      target_compile_options(
+        ${TEST_NAME}
+        PUBLIC
+          $<$<COMPILE_LANGUAGE:CUDA>:-O0
+          -Xcompiler=--coverage,-fprofile-abs-path,-fkeep-inline-functions,-fno-elide-constructors>
+      )
+      target_compile_options(
+        ${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-O0 --coverage -fprofile-abs-path
+                            -fkeep-inline-functions -fno-elide-constructors>
+      )
+      target_link_options(${TEST_NAME} PRIVATE --coverage)
+      target_link_libraries(${TEST_NAME} gcov)
     endif()
 
-    set_target_properties(
-            ${TEST_NAME}
-            PROPERTIES POSITION_INDEPENDENT_CODE ON
-            RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${WHOLEGRAPH_BINARY_DIR}/gtests>"
-            CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}"
-            INSTALL_RPATH "\$ORIGIN/../../../lib")
-    target_compile_definitions(${TEST_NAME}
-            PUBLIC "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${WHOLEGRAPH_LOGGING_LEVEL}")
-    target_compile_options(${TEST_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror
-            -Wno-error=deprecated-declarations>)
+    # Add coverage-generated files to clean target
+    list(APPEND COVERAGE_CLEAN_FILES "**/*.gcno" "**/*.gcda")
+    set_property(
+      TARGET ${TEST_NAME}
+      APPEND
+      PROPERTY ADDITIONAL_CLEAN_FILES ${COVERAGE_CLEAN_FILES}
+    )
+  endif()
 
-    if(DISABLE_DEPRECATION_WARNING)
-        target_compile_options(
-                ${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-deprecated-declarations>)
-        target_compile_options(${TEST_NAME}
-                PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
-    endif()
-
-    if(CODE_COVERAGE)
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-
-            set(KEEP_DIR ${CMAKE_CURRENT_BINARY_DIR}/tmp)
-            make_directory(${KEEP_DIR})
-            target_compile_options(${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:--keep
-                    --keep-dir=${KEEP_DIR}>)
-            target_compile_options(
-                    ${TEST_NAME}
-                    PUBLIC
-                    $<$<COMPILE_LANGUAGE:CUDA>:-O0
-                    -Xcompiler=--coverage,-fprofile-abs-path,-fkeep-inline-functions,-fno-elide-constructors>)
-            target_compile_options(
-                    ${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-O0 --coverage -fprofile-abs-path
-                    -fkeep-inline-functions -fno-elide-constructors>)
-            target_link_options(${TEST_NAME} PRIVATE --coverage)
-            target_link_libraries(${TEST_NAME} gcov)
-        endif()
-
-        # Add coverage-generated files to clean target
-        list(APPEND COVERAGE_CLEAN_FILES "**/*.gcno" "**/*.gcda")
-        set_property(
-                TARGET ${TEST_NAME}
-                APPEND
-                PROPERTY ADDITIONAL_CLEAN_FILES ${COVERAGE_CLEAN_FILES})
-    endif()
-
-    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
-    set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{LD_LIBRARY_PATH}")
-    install(
-            TARGETS ${TEST_NAME}
-            COMPONENT testing
-            DESTINATION bin/gtests/libwholegraph
-            EXCLUDE_FROM_ALL)
+  add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+  set_tests_properties(
+    ${TEST_NAME} PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:$ENV{LD_LIBRARY_PATH}"
+  )
+  install(
+    TARGETS ${TEST_NAME}
+    COMPONENT testing
+    DESTINATION bin/gtests/libwholegraph
+    EXCLUDE_FROM_ALL
+  )
 endfunction()
 
 # Wrapper around `ConfigureTestInternal` that builds tests both with and without per thread default
 # stream
 function(ConfigureTest TEST_NAME)
-    # Test with legacy default stream.
-    ConfigureTestInternal(${TEST_NAME} ${ARGN})
+  # Test with legacy default stream.
+  ConfigureTestInternal(${TEST_NAME} ${ARGN})
 endfunction()
 
 # parallel_utils tests
@@ -102,28 +115,55 @@ ConfigureTest(WHOLEMEMORY_HANDLE_TEST wholememory/wholememory_handle_tests.cpp)
 ConfigureTest(WHOLEMEMORY_TENSOR_TEST wholememory/wholememory_tensor_tests.cpp)
 
 # wholememory gather op tests
-ConfigureTest(WHOLEMEMORY_GATHER_TEST wholememory_ops/wholememory_gather_tests.cu wholememory_ops/embedding_test_utils.cu)
+ConfigureTest(
+  WHOLEMEMORY_GATHER_TEST wholememory_ops/wholememory_gather_tests.cu
+  wholememory_ops/embedding_test_utils.cu
+)
 
 # wholememory scatter op tests
-ConfigureTest(WHOLEMEMORY_SCATTER_TEST wholememory_ops/wholememory_scatter_tests.cu wholememory_ops/embedding_test_utils.cu)
+ConfigureTest(
+  WHOLEMEMORY_SCATTER_TEST wholememory_ops/wholememory_scatter_tests.cu
+  wholememory_ops/embedding_test_utils.cu
+)
 
-#wholegraph unweighted samping op tests
-ConfigureTest(WHOLEGRAPH_CSR_UNWEIGHTED_SAMPLE_WITHOUT_REPLACEMENT_TEST wholegraph_ops/wholegraph_csr_unweighted_sample_without_replacement_tests.cu wholegraph_ops/graph_sampling_test_utils.cu)
+# wholegraph unweighted samping op tests
+ConfigureTest(
+  WHOLEGRAPH_CSR_UNWEIGHTED_SAMPLE_WITHOUT_REPLACEMENT_TEST
+  wholegraph_ops/wholegraph_csr_unweighted_sample_without_replacement_tests.cu
+  wholegraph_ops/graph_sampling_test_utils.cu
+)
 
-#wholegraph weighted samping op tests
-ConfigureTest(WHOLEGRAPH_CSR_WEIGHTED_SAMPLE_WITHOUT_REPLACEMENT_TEST wholegraph_ops/wholegraph_csr_weighted_sample_without_replacement_tests.cu wholegraph_ops/graph_sampling_test_utils.cu)
+# wholegraph weighted samping op tests
+ConfigureTest(
+  WHOLEGRAPH_CSR_WEIGHTED_SAMPLE_WITHOUT_REPLACEMENT_TEST
+  wholegraph_ops/wholegraph_csr_weighted_sample_without_replacement_tests.cu
+  wholegraph_ops/graph_sampling_test_utils.cu
+)
 
-#wholegraph cache set tests
+# wholegraph cache set tests
 ConfigureTest(WHOLEGRAPH_CACHESET_TEST wholememory_ops/cacheset_tests.cu)
 
-#wholegraph embedding tests
-ConfigureTest(WHOLEGRAPH_EMBEDDING_TEST wholememory_ops/wholememory_embedding_tests.cu wholememory_ops/embedding_test_utils.cu)
+# wholegraph embedding tests
+ConfigureTest(
+  WHOLEGRAPH_EMBEDDING_TEST wholememory_ops/wholememory_embedding_tests.cu
+  wholememory_ops/embedding_test_utils.cu
+)
 
-#wholegraph embedding gradient apply tests
-ConfigureTest(WHOLEGRAPH_EMBEDDING_GRADIENT_APPLY_TEST wholememory_ops/wholememory_embedding_gradient_apply_tests.cu wholememory_ops/embedding_test_utils.cu)
+# wholegraph embedding gradient apply tests
+ConfigureTest(
+  WHOLEGRAPH_EMBEDDING_GRADIENT_APPLY_TEST
+  wholememory_ops/wholememory_embedding_gradient_apply_tests.cu
+  wholememory_ops/embedding_test_utils.cu
+)
 
-#graph append unique op tests
-ConfigureTest(GRAPH_APPEND_UNIQUE_TEST graph_ops/append_unique_tests.cu graph_ops/append_unique_test_utils.cu wholegraph_ops/graph_sampling_test_utils.cu)
+# graph append unique op tests
+ConfigureTest(
+  GRAPH_APPEND_UNIQUE_TEST graph_ops/append_unique_tests.cu graph_ops/append_unique_test_utils.cu
+  wholegraph_ops/graph_sampling_test_utils.cu
+)
 
-#graph csr add self loop op tests
-ConfigureTest(GRAPH_CSR_ADD_SELF_LOOP_TEST graph_ops/csr_add_self_loop_tests.cu graph_ops/csr_add_self_loop_utils.cu wholegraph_ops/graph_sampling_test_utils.cu)
+# graph csr add self loop op tests
+ConfigureTest(
+  GRAPH_CSR_ADD_SELF_LOOP_TEST graph_ops/csr_add_self_loop_tests.cu
+  graph_ops/csr_add_self_loop_utils.cu wholegraph_ops/graph_sampling_test_utils.cu
+)

--- a/python/pylibwholegraph/CMakeLists.txt
+++ b/python/pylibwholegraph/CMakeLists.txt
@@ -30,7 +30,6 @@ project(
 # ##################################################################################################
 # * User Options  ------------------------------------------------------------
 
-option(DETECT_CONDA_ENV "Enable detection of conda environment for dependencies" ON)
 option(WHOLEGRAPH_BUILD_WHEELS "Whether we're building a wheel for pypi" OFF)
 
 # ##################################################################################################
@@ -40,16 +39,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # default build type
 rapids_cmake_build_type(Release)
-
-message("CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
-
-if(DETECT_CONDA_ENV)
-  rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
-  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND DEFINED ENV{CONDA_PREFIX})
-    message(STATUS "No CMAKE_INSTALL_PREFIX argument detected, setting to: $ENV{CONDA_PREFIX}")
-    set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
-  endif()
-endif()
 
 rapids_cpm_init()
 
@@ -78,14 +67,6 @@ endif()
 
 include(rapids-cython-core)
 rapids_cython_init()
-
-# ##################################################################################################
-# * Display options ----------------------------------------------------------
-
-message(
-  VERBOSE
-  "PYLIBWHOLEGRAPH: Enable detection of conda environment for dependencies: ${DETECT_CONDA_ENV}"
-)
 
 # ##################################################################################################
 # * Compiler options ---------------------------------------------------------

--- a/python/pylibwholegraph/CMakeLists.txt
+++ b/python/pylibwholegraph/CMakeLists.txt
@@ -1,18 +1,16 @@
-#=============================================================================
+# =============================================================================
 # Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#=============================================================================
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
 
 cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
@@ -29,14 +27,14 @@ project(
   LANGUAGES CXX CUDA
 )
 
-##############################################################################
-# - User Options  ------------------------------------------------------------
+# ##################################################################################################
+# * User Options  ------------------------------------------------------------
 
 option(DETECT_CONDA_ENV "Enable detection of conda environment for dependencies" ON)
 option(WHOLEGRAPH_BUILD_WHEELS "Whether we're building a wheel for pypi" OFF)
 
-##############################################################################
-# - Base Rapids Options  -----------------------------------------------------
+# ##################################################################################################
+# * Base Rapids Options  -----------------------------------------------------
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -46,53 +44,57 @@ rapids_cmake_build_type(Release)
 message("CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
 
 if(DETECT_CONDA_ENV)
-    rapids_cmake_support_conda_env( conda_env MODIFY_PREFIX_PATH )
-    if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND DEFINED ENV{CONDA_PREFIX})
-        message(STATUS "No CMAKE_INSTALL_PREFIX argument detected, setting to: $ENV{CONDA_PREFIX}")
-        set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
-    endif()
+  rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
+  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND DEFINED ENV{CONDA_PREFIX})
+    message(STATUS "No CMAKE_INSTALL_PREFIX argument detected, setting to: $ENV{CONDA_PREFIX}")
+    set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
+  endif()
 endif()
 
 rapids_cpm_init()
 
 include(../../cpp/cmake/thirdparty/get_raft.cmake)
 
-##############################################################################
-# - Dependencies  ------------------------------------------------------------
+# ##################################################################################################
+# * Dependencies  ------------------------------------------------------------
 
 # use <package>_ROOT here to take precedence over any other package
-if (DEFINED ENV{LIBWHOLEGRAPH_DIR})
+if(DEFINED ENV{LIBWHOLEGRAPH_DIR})
   set(wholegraph_ROOT "$ENV{LIBWHOLEGRAPH_DIR}")
 endif()
 find_package(wholegraph "${RAPIDS_VERSION_MAJOR_MINOR}.0" EXACT)
 message("WholeGraph")
-if (WHOLEGRAPH_FOUND)
-    message(STATUS "PYLIBWHOLEGRAPH: using pre-built wholegraph C++ package")
+if(WHOLEGRAPH_FOUND)
+  message(STATUS "PYLIBWHOLEGRAPH: using pre-built wholegraph C++ package")
 elseif(WHOLEGRAPH_BUILD_WHEELS)
-    # statically link dependencies if building wheels
-    message(STATUS "PYLIBWHOLEGRAPH: build wheels")
-    add_subdirectory(../../cpp/ libwholegraph EXCLUDE_FROM_ALL)
+  # statically link dependencies if building wheels
+  message(STATUS "PYLIBWHOLEGRAPH: build wheels")
+  add_subdirectory(../../cpp/ libwholegraph EXCLUDE_FROM_ALL)
 else()
-    message(FATAL_ERROR "PYLIBWHOLEGRAPH: could not find wholegraph package in "
-            "cmake prefix ${CMAKE_PREFIX_PATH} or user dir $ENV{LIBWHOLEGRAPH_DIR}")
+  message(FATAL_ERROR "PYLIBWHOLEGRAPH: could not find wholegraph package in "
+                      "cmake prefix ${CMAKE_PREFIX_PATH} or user dir $ENV{LIBWHOLEGRAPH_DIR}"
+  )
 endif()
 
 include(rapids-cython-core)
 rapids_cython_init()
 
-##############################################################################
-# - Display options ----------------------------------------------------------
+# ##################################################################################################
+# * Display options ----------------------------------------------------------
 
-message(VERBOSE "PYLIBWHOLEGRAPH: Enable detection of conda environment for dependencies: ${DETECT_CONDA_ENV}")
+message(
+  VERBOSE
+  "PYLIBWHOLEGRAPH: Enable detection of conda environment for dependencies: ${DETECT_CONDA_ENV}"
+)
 
-##############################################################################
-# - Compiler options ---------------------------------------------------------
+# ##################################################################################################
+# * Compiler options ---------------------------------------------------------
 
 message(STATUS "PYLIBWHOLEGRAPH: DEFAULT_CXX_FLAGS='${DEFAULT_CXX_FLAGS}'")
 message(STATUS "PYLIBWHOLEGRAPH: CXX_FLAGS='${CXX_FLAGS}'")
 message(STATUS "PYLIBWHOLEGRAPH: CXX_DEFINITIONS='${CXX_DEFINITIONS}'")
 
-##############################################################################
-# - Cython modules -----------------------------------------------------------
+# ##################################################################################################
+# * Cython modules -----------------------------------------------------------
 
 add_subdirectory(pylibwholegraph/binding)

--- a/python/pylibwholegraph/pylibwholegraph/binding/CMakeLists.txt
+++ b/python/pylibwholegraph/pylibwholegraph/binding/CMakeLists.txt
@@ -1,18 +1,16 @@
-#=============================================================================
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# =============================================================================
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#=============================================================================
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
 
 # Set the list of Cython files to build
 set(cython_sources wholememory_binding.pyx)
@@ -20,8 +18,7 @@ set(linked_libraries wholegraph::wholegraph)
 
 # Build all of the Cython targets
 rapids_cython_create_modules(
-        CXX
-        SOURCE_FILES "${cython_sources}"
-        LINKED_LIBRARIES "${linked_libraries}"
-        ASSOCIATED_TARGETS wholegraph
-        MODULE_PREFIX wholegraphcif)
+  CXX
+  SOURCE_FILES "${cython_sources}"
+  LINKED_LIBRARIES "${linked_libraries}" ASSOCIATED_TARGETS wholegraph MODULE_PREFIX wholegraphcif
+)

--- a/rapids_config.cmake
+++ b/rapids_config.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -22,13 +22,15 @@ else()
   string(REPLACE "\n" "\n  " _rapids_version_formatted "  ${_rapids_version}")
   message(
     FATAL_ERROR
-      "Could not determine RAPIDS version. Contents of VERSION file:\n${_rapids_version_formatted}")
+      "Could not determine RAPIDS version. Contents of VERSION file:\n${_rapids_version_formatted}"
+  )
 endif()
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/CUGRAPH_GNN_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")
   file(
     DOWNLOAD
     "https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_VERSION_MAJOR_MINOR}/RAPIDS.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/CUGRAPH_GNN_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")
+    "${CMAKE_CURRENT_BINARY_DIR}/CUGRAPH_GNN_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake"
+  )
 endif()
 include("${CMAKE_CURRENT_BINARY_DIR}/CUGRAPH_GNN_RAPIDS-${RAPIDS_VERSION_MAJOR_MINOR}.cmake")


### PR DESCRIPTION
Part of https://github.com/rapidsai/build-planning/issues/136, which tracks some building/packaging simplifications and conventions we'd like to standardize across RAPIDS.

This proposes the following:

* using `cmake-format` to autoformat CMake code
* using `cmake-lint` to enforce style preferences for CMake code
* removing unnecessary use of `-DDETECT_CONDA_ENV` for wheel builds
* explicitly passing package type to GitHub Actions / `gha-tools` things handling wheels

## Notes for Reviewers

The `cmake-format` / `cmake-lint` approach was copied directly from RAFT:

* https://github.com/rapidsai/raft/blob/596d4b7338e62a92652503cd76feaeaa187ad740/.pre-commit-config.yaml#L52
* https://github.com/rapidsai/raft/blob/596d4b7338e62a92652503cd76feaeaa187ad740/cpp/cmake/config.json
* https://github.com/rapidsai/raft/blob/596d4b7338e62a92652503cd76feaeaa187ad740/cpp/scripts/run-cmake-format.sh

Other RAPIDS projects ([like cuDF](https://github.com/rapidsai/cudf/blob/1f0f51f96b79edd820e81343ca521c684b1f4918/.pre-commit-config.yaml#L97)) do this the same way.

All formatting-only changes to CMake in this PR were made automatically by `cmake-foramt`.