### PR TITLE
Fix of create_node_classification_datasets

### DIFF
--- a/python/pylibwholegraph/examples/node_classfication.py
+++ b/python/pylibwholegraph/examples/node_classfication.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/pylibwholegraph/examples/node_classfication.py
+++ b/python/pylibwholegraph/examples/node_classfication.py
@@ -18,6 +18,7 @@ import argparse
 
 import apex
 import torch
+import pickle
 from apex.parallel import DistributedDataParallel as DDP
 import pylibwholegraph.torch as wgth
 
@@ -141,8 +142,12 @@ def main_func():
     if args.use_cpp_ext:
         wgth.compile_cpp_extension()
 
-    train_ds, valid_ds, test_ds = wgth.create_node_claffication_datasets(
-        args.pickle_data_path
+    data_and_label = dict()
+    with open(args.pickle_data_path, "rb") as f:
+        data_and_label = pickle.load(f)
+
+    train_ds, valid_ds, test_ds = wgth.create_node_classification_datasets(
+        data_and_label
     )
 
     graph_structure = wgth.GraphStructure()

--- a/python/pylibwholegraph/pylibwholegraph/torch/__init__.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/pylibwholegraph/pylibwholegraph/torch/__init__.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/__init__.py
@@ -76,7 +76,7 @@ from .common_options import (
 
 from .gnn_model import set_framework, create_gnn_layers, create_sub_graph, HomoGNNModel
 from .data_loader import (
-    create_node_claffication_datasets,
+    create_node_classification_datasets,
     get_train_dataloader,
     get_valid_test_dataloader,
 )

--- a/python/pylibwholegraph/pylibwholegraph/torch/data_loader.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/data_loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/python/pylibwholegraph/pylibwholegraph/torch/data_loader.py
+++ b/python/pylibwholegraph/pylibwholegraph/torch/data_loader.py
@@ -13,7 +13,6 @@
 
 import numpy as np
 import torch
-import pickle
 from torch.utils.data import Dataset
 
 
@@ -28,10 +27,7 @@ class NodeClassificationDataset(Dataset):
         return len(self.dataset)
 
 
-def create_node_claffication_datasets(pickle_data_filename: str):
-    with open(pickle_data_filename, "rb") as f:
-        data_and_label = pickle.load(f)
-
+def create_node_classification_datasets(data_and_label: dict):
     train_data = {
         "idx": data_and_label["train_idx"],
         "label": data_and_label["train_label"],


### PR DESCRIPTION
quick fix to create_node_classification function: use data_and_label dict as the parameter instead of pickle_data_path