### PR TITLE
Update CuPy Version to 13.2

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -14,7 +14,7 @@ dependencies:
 - cudatoolkit
 - cudf==25.4.*,>=0.0.0a0
 - cugraph==25.4.*,>=0.0.0a0
-- cupy>=12.0.0
+- cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
 - dglteam/label/th23_cu118::dgl>=2.4.0.th23.cu*

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-version=12.1
 - cudf==25.4.*,>=0.0.0a0
 - cugraph==25.4.*,>=0.0.0a0
-- cupy>=12.0.0
+- cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
 - dglteam/label/th23_cu121::dgl>=2.4.0.th23.cu*

--- a/conda/environments/all_cuda-124_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-124_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-version=12.4
 - cudf==25.4.*,>=0.0.0a0
 - cugraph==25.4.*,>=0.0.0a0
-- cupy>=12.0.0
+- cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
 - dglteam/label/th23_cu121::dgl>=2.4.0.th23.cu*

--- a/conda/recipes/cugraph-dgl/meta.yaml
+++ b/conda/recipes/cugraph-dgl/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - tensordict >=0.1.2
     - python
     - pytorch >=2.3
-    - cupy >=12.0.0
+    - cupy >=13.2.0
 
 tests:
   imports:

--- a/conda/recipes/cugraph-pyg/meta.yaml
+++ b/conda/recipes/cugraph-pyg/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - pandas
     - python
     - pytorch >=2.3
-    - cupy >=12.0.0
+    - cupy >=13.2.0
     - cugraph ={{ minor_version }}
     - tensordict >=0.1.2
     - pytorch_geometric >=2.5,<2.7

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -644,7 +644,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - cupy>=12.0.0
+          - cupy>=13.2.0
     # NOTE: This is intentionally not broken into groups by a 'cuda_suffixed' selector like
     #       other packages with -cu{nn}x suffixes in this file.
     #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
@@ -653,8 +653,8 @@ dependencies:
         matrices:
           - matrix: {cuda: "12.*"}
             packages:
-              - cupy-cuda12x>=12.0.0
+              - cupy-cuda12x>=13.2.0
           - matrix: {cuda: "11.*"}
             packages: &cupy_packages_cu11
-              - cupy-cuda11x>=12.0.0
+              - cupy-cuda11x>=13.2.0
           - {matrix: null, packages: *cupy_packages_cu11}


### PR DESCRIPTION
CuPy 13.2 released a major fix that resolved an ongoing issue with NCCL (https://github.com/rapidsai/cugraph/issues/4465).  At this point, we are relying on other constraints to enforce the CuPy version, but to be safe, we should explicitly upgrade it.

Closes #22 