### PR TITLE
[BUG] Fix bug with drop_last when mod is 0

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/loader/link_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/loader/link_loader.py
@@ -186,7 +186,8 @@ class LinkLoader:
 
         if self.__drop_last:
             d = perm.numel() % self.__batch_size
-            perm = perm[:-d]
+            if d > 0:
+                perm = perm[:-d]
 
         input_data = torch_geometric.sampler.EdgeSamplerInput(
             input_id=self.__input_data.input_id[perm],

--- a/python/cugraph-pyg/cugraph_pyg/loader/node_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/loader/node_loader.py
@@ -137,7 +137,8 @@ class NodeLoader:
 
         if self.__drop_last:
             d = perm.numel() % self.__batch_size
-            perm = perm[:-d]
+            if d > 0:
+                perm = perm[:-d]
 
         input_data = torch_geometric.sampler.NodeSamplerInput(
             input_id=self.__input_data.input_id[perm],


### PR DESCRIPTION
Closes #130 .  Will be accompanied by a PR to `cugraph` that shows how many batches reached each worker, so it is obvious when there are more GPUs than batches.

Resolves a bug where `drop_last` deleted all input if the length of the input modulo batch size was 0.