### PR TITLE
Update DGL Packages to PyTorch 2.4

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
-- dglteam/label/th24_cu118::dgl>=2.4.0.th24.cu*
+- dglteam/label/th24_cu118::dgl>=2.4.0
 - doxygen
 - gcc_linux-64=11.*
 - graphviz

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
-- dglteam/label/th24_cu118::dgl>=2.4.0
+- dglteam/label/th24_cu118::dgl
 - doxygen
 - gcc_linux-64=11.*
 - graphviz

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
-- dglteam/label/th23_cu118::dgl>=2.4.0.th23.cu*
+- dglteam/label/th24_cu118::dgl>=2.4.0.th24.cu*
 - doxygen
 - gcc_linux-64=11.*
 - graphviz

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
-- dglteam/label/th24_cu124::dgl>=2.4.0.th24.cu*
+- dglteam/label/th24_cu124::dgl>=2.4.0
 - doxygen
 - gcc_linux-64=13.*
 - graphviz

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
-- dglteam/label/th23_cu121::dgl>=2.4.0.th23.cu*
+- dglteam/label/th24_cu124::dgl>=2.4.0.th24.cu*
 - doxygen
 - gcc_linux-64=13.*
 - graphviz

--- a/conda/environments/all_cuda-121_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-121_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
-- dglteam/label/th24_cu124::dgl>=2.4.0
+- dglteam/label/th24_cu124::dgl
 - doxygen
 - gcc_linux-64=13.*
 - graphviz

--- a/conda/environments/all_cuda-124_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-124_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
-- dglteam/label/th24_cu124::dgl>=2.4.0.th24.cu*
+- dglteam/label/th24_cu124::dgl>=2.4.0
 - doxygen
 - gcc_linux-64=13.*
 - graphviz

--- a/conda/environments/all_cuda-124_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-124_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
-- dglteam/label/th23_cu121::dgl>=2.4.0.th23.cu*
+- dglteam/label/th24_cu124::dgl>=2.4.0.th24.cu*
 - doxygen
 - gcc_linux-64=13.*
 - graphviz

--- a/conda/environments/all_cuda-124_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-124_arch-x86_64.yaml
@@ -20,7 +20,7 @@ dependencies:
 - cupy>=13.2.0
 - cython>=3.0.0
 - dask-cudf==25.4.*,>=0.0.0a0
-- dglteam/label/th24_cu124::dgl>=2.4.0
+- dglteam/label/th24_cu124::dgl
 - doxygen
 - gcc_linux-64=13.*
 - graphviz

--- a/conda/recipes/cugraph-dgl/meta.yaml
+++ b/conda/recipes/cugraph-dgl/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools>=61.0.0
   run:
     - cugraph ={{ minor_version }}
-    - dgl >=2.4.0.th23.cu*
+    - dgl >=2.4.0.th24.cu*
     - numba >=0.57
     - numpy >=1.23,<3.0a0
     - pandas

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -469,11 +469,11 @@ dependencies:
         matrices:
           - matrix: {cuda: "12.*"}
             packages:
-              - "dglteam/label/th24_cu124::dgl>=2.4.0.th24.cu*"
+              - "dglteam/label/th24_cu124::dgl>=2.4.0"
           - matrix: {cuda: "11.*"}
             packages:
-              - "dglteam/label/th24_cu118::dgl>=2.4.0.th24.cu*"
-          - {matrix: null, packages: ["dglteam/label/th24_cu124::dgl>=2.4.0.th24.cu*"]}
+              - "dglteam/label/th24_cu118::dgl>=2.4.0"
+          - {matrix: null, packages: ["dglteam/label/th24_cu124::dgl>=2.4.0"]}
 
   depends_on_pyg:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -469,11 +469,11 @@ dependencies:
         matrices:
           - matrix: {cuda: "12.*"}
             packages:
-              - "dglteam/label/th24_cu124::dgl>=2.4.0"
+              - "dglteam/label/th24_cu124::dgl"
           - matrix: {cuda: "11.*"}
             packages:
-              - "dglteam/label/th24_cu118::dgl>=2.4.0"
-          - {matrix: null, packages: ["dglteam/label/th24_cu124::dgl>=2.4.0"]}
+              - "dglteam/label/th24_cu118::dgl"
+          - {matrix: null, packages: ["dglteam/label/th24_cu124::dgl"]}
 
   depends_on_pyg:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -469,11 +469,11 @@ dependencies:
         matrices:
           - matrix: {cuda: "12.*"}
             packages:
-              - "dglteam/label/th23_cu121::dgl>=2.4.0.th23.cu*"
+              - "dglteam/label/th24_cu124::dgl>=2.4.0.th24.cu*"
           - matrix: {cuda: "11.*"}
             packages:
-              - "dglteam/label/th23_cu118::dgl>=2.4.0.th23.cu*"
-          - {matrix: null, packages: ["dglteam/label/th23_cu121::dgl>=2.4.0.th23.cu*"]}
+              - "dglteam/label/th24_cu118::dgl>=2.4.0.th24.cu*"
+          - {matrix: null, packages: ["dglteam/label/th24_cu124::dgl>=2.4.0.th24.cu*"]}
 
   depends_on_pyg:
     common:

--- a/python/cugraph-dgl/conda/cugraph_dgl_dev_cuda-118.yaml
+++ b/python/cugraph-dgl/conda/cugraph_dgl_dev_cuda-118.yaml
@@ -9,7 +9,7 @@ channels:
 dependencies:
 - cugraph==25.4.*,>=0.0.0a0
 - dgl>=2.4.0.cu*
-- dglteam/label/th23_cu118::dgl>=2.4.0.th23.cu*
+- dglteam/label/th24_cu118::dgl>=2.4.0.th24.cu*
 - pre-commit
 - pydantic
 - pytest

--- a/python/cugraph-dgl/conda/cugraph_dgl_dev_cuda-118.yaml
+++ b/python/cugraph-dgl/conda/cugraph_dgl_dev_cuda-118.yaml
@@ -9,7 +9,7 @@ channels:
 dependencies:
 - cugraph==25.4.*,>=0.0.0a0
 - dgl>=2.4.0.cu*
-- dglteam/label/th24_cu118::dgl>=2.4.0
+- dglteam/label/th24_cu118::dgl
 - pre-commit
 - pydantic
 - pytest

--- a/python/cugraph-dgl/conda/cugraph_dgl_dev_cuda-118.yaml
+++ b/python/cugraph-dgl/conda/cugraph_dgl_dev_cuda-118.yaml
@@ -9,7 +9,7 @@ channels:
 dependencies:
 - cugraph==25.4.*,>=0.0.0a0
 - dgl>=2.4.0.cu*
-- dglteam/label/th24_cu118::dgl>=2.4.0.th24.cu*
+- dglteam/label/th24_cu118::dgl>=2.4.0
 - pre-commit
 - pydantic
 - pytest


### PR DESCRIPTION
Update the DGL packages to those using PyTorch 2.4, since the DGL 2.4 packages for PyTorch 2.3 are no longer available.  Should unblock CI.