### PR TITLE
add cugraph-notebook-codeowners to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,3 +27,6 @@ cpp/               @rapidsai/wholegraph-cpp-codeowners
 /build.sh          @rapidsai/packaging-codeowners
 pyproject.toml     @rapidsai/packaging-codeowners
 VERSION            @rapidsai/packaging-codeowners
+
+# notebooks code owners
+*.ipynb @cugraph-notebook-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,4 +29,4 @@ pyproject.toml     @rapidsai/packaging-codeowners
 VERSION            @rapidsai/packaging-codeowners
 
 # notebooks code owners
-*.ipynb @cugraph-notebook-codeowners
+*.ipynb @rapidsai/cugraph-notebook-codeowners


### PR DESCRIPTION
Makes all `.ipynb` files reviewable by `@cugraph-notebook-codeowners`