### PR TITLE
Use conda-build instead of conda-mambabuild

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -17,7 +17,7 @@ rapids-logger "Begin cpp build"
 
 sccache --zero-stats
 
-RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry mambabuild conda/recipes/libwholegraph
+RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry build conda/recipes/libwholegraph
 
 sccache --show-adv-stats
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -22,19 +22,19 @@ sccache --zero-stats
 # TODO: Remove `--no-test` flags once importing on a CPU
 # node works correctly
 rapids-logger "Begin pylibwholegraph build"
-RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry mambabuild \
+RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/pylibwholegraph
 
 sccache --show-adv-stats
 
-RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry mambabuild \
+RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cugraph-pyg
 
-RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry mambabuild \
+RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cugraph-dgl

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -16,7 +16,7 @@ rapids-dependency-file-generator \
   --output conda \
   --file-key test_notebooks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}"  \
-  --prepend-channel dglteam/label/th23_cu118 \
+  --prepend-channel dglteam/label/th24_cu118 \
   --prepend-channel "${CPP_CHANNEL}" \
   --prepend-channel "${PYTHON_CHANNEL}" \
 | tee env.yaml

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -7,9 +7,9 @@ set -euo pipefail
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 if [[ "${RAPIDS_CUDA_VERSION%%.*}" == "11" ]]; then
-  DGL_CHANNEL="dglteam/label/th23_cu118"
+  DGL_CHANNEL="dglteam/label/th24_cu118"
 else
-  DGL_CHANNEL="dglteam/label/th23_cu121"
+  DGL_CHANNEL="dglteam/label/th24_cu124"
 fi
 
 . /opt/conda/etc/profile.d/conda.sh

--- a/python/cugraph-dgl/README.md
+++ b/python/cugraph-dgl/README.md
@@ -10,10 +10,10 @@ Install and update cugraph-dgl and the required dependencies using the command:
 
 ```
 # CUDA 11
-conda install -c rapidsai -c pytorch -c conda-forge -c nvidia -c dglteam/label/th23_cu118 cugraph-dgl
+conda install -c rapidsai -c pytorch -c conda-forge -c nvidia -c dglteam/label/th24_cu118 cugraph-dgl
 
 # CUDA 12
-conda install -c rapidsai -c pytorch -c conda-forge -c nvidia -c dglteam/label/th23_cu121 cugraph-dgl
+conda install -c rapidsai -c pytorch -c conda-forge -c nvidia -c dglteam/label/th24_cu124 cugraph-dgl
 ```
 
 ## Build from Source


### PR DESCRIPTION
This changes from `conda mambabuild` to `conda build`. Conda now uses the mamba solver so no performance regressions are expected.

This is a temporary change as we plan to migrate to `rattler-build` in the near future. However, this is needed sooner to drop `boa` and unblock Python 3.13 migrations.

xref: https://github.com/rapidsai/build-planning/issues/149
