### PR TITLE
Update PyTorch to use CUDA 12.6

### DIFF
--- a/ci/test_wheel_cugraph-pyg.sh
+++ b/ci/test_wheel_cugraph-pyg.sh
@@ -12,20 +12,9 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python ./local-deps
 RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-s3 python ./dist
 
-# determine pytorch and pyg sources
-if [[ "${CUDA_VERSION}" == "11.8.0" ]]; then
-  PYTORCH_URL="https://download.pytorch.org/whl/cu118"
-  PYG_URL="https://data.pyg.org/whl/torch-2.3.0+cu118.html"
-else
-  PYTORCH_URL="https://download.pytorch.org/whl/cu121"
-  PYG_URL="https://data.pyg.org/whl/torch-2.3.0+cu121.html"
-fi
-
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install \
     -v \
-    --extra-index-url "${PYTORCH_URL}" \
-    --find-links "${PYG_URL}" \
     "$(echo ./local-deps/pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}*.whl)" \
     "$(echo ./dist/cugraph_pyg_${RAPIDS_PY_CUDA_SUFFIX}*.whl)[test]"
 

--- a/conda/environments/all_cuda-126_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-126_arch-x86_64.yaml
@@ -14,7 +14,7 @@ dependencies:
 - cuda-nvml-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-version=12.1
+- cuda-version=12.6
 - cudf==25.4.*,>=0.0.0a0
 - cugraph==25.4.*,>=0.0.0a0
 - cupy>=13.2.0
@@ -53,4 +53,4 @@ dependencies:
 - setuptools>=61.0.0
 - torchdata
 - wheel
-name: all_cuda-121_arch-x86_64
+name: all_cuda-126_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -5,7 +5,7 @@ files:
     matrix:
       # CUDA versions match PyTorch releases, not RAPIDS
       # ref: https://pytorch.org/get-started/locally/
-      cuda: ["11.8", "12.1", "12.4"]
+      cuda: ["11.8", "12.4", "12.6"]
       arch: [x86_64]
     includes:
       - checks
@@ -270,6 +270,10 @@ dependencies:
             packages:
               - cuda-version=12.5
           - matrix:
+              cuda: "12.6"
+            packages:
+              - cuda-version=12.6
+          - matrix:
               cuda: "12.8"
             packages:
               - cuda-version=12.8
@@ -454,7 +458,7 @@ dependencies:
         matrices:
           - matrix: {cuda: "12.*"}
             packages:
-              - --extra-index-url=https://download.pytorch.org/whl/cu121
+              - --extra-index-url=https://download.pytorch.org/whl/cu126
           - matrix: {cuda: "11.*"}
             packages:
               - --extra-index-url=https://download.pytorch.org/whl/cu118


### PR DESCRIPTION
Updates the PyTorch test dependency to install the version for CUDA 12.6.  This is the latest CUDA version supported by PyTorch.  CUDA 12.1 support is being dropped.

Closes #154 