### PR TITLE
Deprecate TensorDictFeatureStore in cuGraph-PyG

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/data/__init__.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/__init__.py
@@ -18,9 +18,18 @@ from cugraph_pyg.data.dask_graph_store import (
 )
 from cugraph_pyg.data.graph_store import GraphStore
 from cugraph_pyg.data.feature_store import (
-    TensorDictFeatureStore,
+    TensorDictFeatureStore as DEPRECATED__TensorDictFeatureStore,
     WholeFeatureStore,
 )
+
+
+def TensorDictFeatureStore(*args, **kwargs):
+    warnings.warn(
+        "TensorDictFeatureStore is deprecated.  Consider changing your "
+        "workflow to launch using 'torchrun' and store data in "
+        "the faster and more memory-efficient WholeFeatureStore instead.",
+        FutureWarning,
+    )
 
 
 def DaskGraphStore(*args, **kwargs):

--- a/python/cugraph-pyg/cugraph_pyg/data/__init__.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/__init__.py
@@ -31,6 +31,8 @@ def TensorDictFeatureStore(*args, **kwargs):
         FutureWarning,
     )
 
+    return DEPRECATED__TensorDictFeatureStore(*args, **kwargs)
+
 
 def DaskGraphStore(*args, **kwargs):
     warnings.warn(


### PR DESCRIPTION
First step in handling #159 .  The unified API will store all data in WholeGraph, which has superior performance and lower memory usage.  `TensorDictFeatureStore` is no longer a useful alternative.