### PR TITLE
fix(libwholegraph): set build_type to "nightly" and also publish wheel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -118,7 +118,7 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.06
     with:
-      build_type: pull-request
+      build_type: ${{ inputs.build_type || 'branch' }}
       script: ci/build_wheel_libwholegraph.sh
       package-name: libwholegraph
       package-type: cpp
@@ -136,6 +136,17 @@ jobs:
       script: ci/build_wheel_pylibwholegraph.sh
       package-name: pylibwholegraph
       package-type: python
+  wheel-publish-libwholegraph:
+    needs: wheel-build-libwholegraph
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.06
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      package-name: libwholegraph
+      package-type: cpp
   wheel-publish-pylibwholegraph:
     needs: wheel-build-pylibwholegraph
     secrets: inherit


### PR DESCRIPTION
Followup and fixes for #182

I forget to update "build-type" when copying over the new job from `py.yaml` to
`build.yaml` so nightly jobs were looking for an artifact in the nightly bucket
path, but the artifacts were uploaded to the pr path.

Also added a wheel publish step which I missed in the first PR.

