### PR TITLE
[BUG] Fix DGL Test

### DIFF
--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -16,7 +16,6 @@ rapids-dependency-file-generator \
   --output conda \
   --file-key test_notebooks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}"  \
-  --prepend-channel "dglteam/label/th24_cu124" \
   --prepend-channel "${CPP_CHANNEL}" \
   --prepend-channel "${PYTHON_CHANNEL}" \
 | tee env.yaml

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -55,7 +55,6 @@ files:
     includes:
       - cuda_version
       - depends_on_pytorch
-      - depends_on_cugraph_dgl
       - py_version
       - test_notebook
   test_python:

--- a/python/cugraph-dgl/cugraph_dgl/tests/test_graph_mg.py
+++ b/python/cugraph-dgl/cugraph_dgl/tests/test_graph_mg.py
@@ -75,9 +75,11 @@ def run_test_graph_make_homogeneous_graph_mg(rank, uid, world_size, direction):
         graph.nodes()
         == torch.arange(global_num_nodes, dtype=torch.int64, device="cuda")
     ).all()
-    ix = torch.arange(len(node_x) * rank, len(node_x) * (rank + 1), dtype=torch.int64)
+    ix = torch.tensor_split(
+        torch.arange(global_num_nodes, dtype=torch.int64, device="cuda"), world_size
+    )[rank]
     assert graph.nodes[ix]["x"] is not None
-    assert (graph.nodes[ix]["x"] == torch.as_tensor(node_x, device="cuda")).all()
+    assert (graph.nodes[ix]["x"] == ix).all()
 
     assert (
         graph.edges("eid", device="cuda")


### PR DESCRIPTION
Fixes a cuGraph-DGL test that crashes/hangs with 3+ GPUs.  Should resolve the issues seen by the container team.  Drops the requirement for `DGL` from notebook tests to unblock CI.