### PR TITLE
use 'rapids-init-pip' in wheel CI, other CI changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
-      script: build_cpp.sh
+      script: ci/build_cpp.sh
       sha: ${{ inputs.sha }}
   python-build:
     needs: [cpp-build]
@@ -43,7 +43,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
-      script: build_python.sh
+      script: ci/build_python.sh
       sha: ${{ inputs.sha }}
   docs-build:
     needs: cpp-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: build_cpp.sh
       sha: ${{ inputs.sha }}
   python-build:
     needs: [cpp-build]
@@ -42,6 +43,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: build_python.sh
       sha: ${{ inputs.sha }}
   docs-build:
     needs: cpp-build
@@ -53,7 +55,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       container_image: "rapidsai/ci-conda:latest"
       date: ${{ inputs.date }}
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}
   upload-conda:
     needs: [cpp-build, python-build]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,6 +56,7 @@ jobs:
           - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
+          - '!ci/release/update-version.sh'
           - '!img/**'
           - '!mg_utils/**'
           - '!notebooks/**'
@@ -66,12 +67,14 @@ jobs:
           - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
+          - '!ci/release/update-version.sh'
           - '!readme_pages/**'
         test_python:
           - '**'
           - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
+          - '!ci/release/update-version.sh'
           - '!img/**'
           - '!notebooks/**'
           - '!readme_pages/**'
@@ -96,6 +99,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-25.06
     with:
       build_type: pull-request
+      script: ci/build_cpp.sh
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
@@ -103,12 +107,14 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
+      script: ci/test_cpp.sh
   conda-python-build:
     needs: conda-cpp-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
     with:
       build_type: pull-request
+      script: ci/build_python.sh
   conda-notebook-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -119,7 +125,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/test_notebooks.sh"
+      script: "ci/test_notebooks.sh"
   conda-python-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -128,6 +134,7 @@ jobs:
     with:
       build_type: pull-request
       matrix_filter: map(select(.ARCH == "amd64" and .CUDA_VER != "11.4.3" and .PY_VER != "3.13" ))
+      script: ci/test_python.sh
   docs-build:
     needs: conda-cpp-build
     secrets: inherit
@@ -136,7 +143,7 @@ jobs:
       arch: "amd64"
       build_type: pull-request
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/build_docs.sh"
+      script: "ci/build_docs.sh"
   wheel-build-libwholegraph:
     needs: checks
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/test_cpp.sh
       sha: ${{ inputs.sha }}
   conda-notebook-tests:
     secrets: inherit
@@ -36,7 +37,7 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:latest"
-      run_script: "ci/test_notebooks.sh"
+      script: "ci/test_notebooks.sh"
   conda-python-tests:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.06
@@ -44,6 +45,7 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/test_python.sh
       sha: ${{ inputs.sha }}
       matrix_filter: map(select((.ARCH == "amd64") and (.CUDA_VER | startswith("11.4") | not) and (.PY_VER != "3.13") ))
   wheel-tests-pylibwholegraph:

--- a/ci/build_wheel_cugraph-dgl.sh
+++ b/ci/build_wheel_cugraph-dgl.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_dir="python/cugraph-dgl"
 
 ./ci/build_wheel.sh cugraph-dgl ${package_dir} python

--- a/ci/build_wheel_cugraph-pyg.sh
+++ b/ci/build_wheel_cugraph-pyg.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_dir="python/cugraph-pyg"
 
 ./ci/build_wheel.sh cugraph-pyg ${package_dir} python

--- a/ci/build_wheel_libwholegraph.sh
+++ b/ci/build_wheel_libwholegraph.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_dir="python/libwholegraph"
 
 export SKBUILD_CMAKE_ARGS="-DBUILD_SHARED_LIBS=ON;-DCMAKE_MESSAGE_LOG_LEVEL=VERBOSE;-DCUDA_STATIC_RUNTIME=ON"

--- a/ci/build_wheel_pylibwholegraph.sh
+++ b/ci/build_wheel_pylibwholegraph.sh
@@ -3,18 +3,19 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 package_dir="python/pylibwholegraph"
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
-# Download the libcugraph wheel built in the previous step and make it
+# Download the libwholegraph wheel built in the previous step and make it
 # available for pip to find.
-LIBWHOLEGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
-echo "libwholegraph-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBWHOLEGRAPH_WHEELHOUSE}"/libwholegraph_*.whl)" >> /tmp/constraints.txt
-
-# Using env variable PIP_CONSTRAINT is necessary to ensure the constraints
+#
+# Using env variable PIP_CONSTRAINT (initialized by 'rapids-init-pip') is necessary to ensure the constraints
 # are used when creating the isolated build environment.
-export PIP_CONSTRAINT="/tmp/constraints.txt"
+LIBWHOLEGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+echo "libwholegraph-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBWHOLEGRAPH_WHEELHOUSE}"/libwholegraph_*.whl)" >> "${PIP_CONSTRAINT}"
 
 export SKBUILD_CMAKE_ARGS="-DBUILD_SHARED_LIBS=ON;-DCMAKE_MESSAGE_LOG_LEVEL=VERBOSE;-DCUDA_STATIC_RUNTIME=ON;-DWHOLEGRAPH_BUILD_WHEELS=ON"
 

--- a/ci/test_wheel_cugraph-dgl.sh
+++ b/ci/test_wheel_cugraph-dgl.sh
@@ -3,9 +3,10 @@
 
 set -eoxu pipefail
 
+source rapids-init-pip
+
 package_name="cugraph-dgl"
 
-mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 # Download the libwholegraph, pylibwholegraph, and cugraph-dgl built in the previous step

--- a/ci/test_wheel_cugraph-pyg.sh
+++ b/ci/test_wheel_cugraph-pyg.sh
@@ -3,9 +3,10 @@
 
 set -eoxu pipefail
 
+source rapids-init-pip
+
 package_name="cugraph-pyg"
 
-mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 # Download the libwholegraph, pylibwholegraph, and cugraph-pyg built in the previous step

--- a/ci/test_wheel_pylibwholegraph.sh
+++ b/ci/test_wheel_pylibwholegraph.sh
@@ -5,7 +5,8 @@ set -e          # abort the script on error
 set -o pipefail # piped commands propagate their error
 set -E          # ERR traps are inherited by subcommands
 
-mkdir -p ./dist
+source rapids-init-pip
+
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 LIBWHOLEGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
 PYLIBWHOLEGRAPH_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="pylibwholegraph_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)


### PR DESCRIPTION
## Description

Proposes a batch of small, mostly-unrelated changes to building and packaging.

These are all part of RAPIDS-wide efforts to make it easier to reproduce CI locally and to use artifacts from one project's CI in another project's CI.

Contributes to https://github.com/rapidsai/build-planning/issues/178

* prevents triggering expensive CI jobs based on PRs modifying `ci/release/update-version.sh`

Contributes to https://github.com/rapidsai/shared-workflows/issues/356

* explicitly provides an input for `script` to workflows using it, instead of relying on a default value coming from the workflow file

Contributes to https://github.com/rapidsai/shared-workflows/issues/337

* switches from input `run_script` to `script` in uses of the `custom-job` workflow

Contributes to https://github.com/rapidsai/build-planning/issues/179

* adds a call to `rapids-init-pip` near the beginning of all CI scripts that use `pip`
* removes redefinitions of `PIP_CONSTRAINT` in scripts, in favor of using the one set up by `rapids-pip-init`

Contributes to https://github.com/rapidsai/gha-tools/issues/145

* confirmed that `rapids-configure-conda-channels` is not used in any builds scripts using `rattler-build`