### PR TITLE
WIP: stop uploading packages to downloads.rapids.ai

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
   upload-conda:
     needs: [cpp-build, python-build]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@gha-artifacts/uploads
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -84,7 +84,7 @@ jobs:
   wheel-publish-cugraph-dgl:
     needs: wheel-build-cugraph-dgl
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@gha-artifacts/uploads
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -109,7 +109,7 @@ jobs:
   wheel-publish-cugraph-pyg:
     needs: wheel-build-cugraph-pyg
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@gha-artifacts/uploads
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -145,7 +145,7 @@ jobs:
   wheel-publish-libwholegraph:
     needs: wheel-build-libwholegraph
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@gha-artifacts/uploads
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -156,7 +156,7 @@ jobs:
   wheel-publish-pylibwholegraph:
     needs: wheel-build-pylibwholegraph
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@gha-artifacts/uploads
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -29,5 +29,3 @@ rattler-build build --recipe conda/recipes/libwholegraph \
                     "${RATTLER_CHANNELS[@]}"
 
 sccache --show-adv-stats
-
-rapids-upload-conda-to-s3 cpp

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -69,5 +69,3 @@ sccache --show-adv-stats
 # remove build_cache directory to avoid uploading the entire source tree
 # tracked in https://github.com/prefix-dev/rattler-build/issues/1424
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
-
-rapids-upload-conda-to-s3 python

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -49,7 +49,6 @@ sccache --show-adv-stats
 # pure-python packages should be marked as pure, and not have auditwheel run on them.
 if [[ ${package_name} == "cugraph-dgl" ]] || \
    [[ ${package_name} == "cugraph-pyg" ]]; then
-    RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 python dist
     cp dist/* "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}/"
 else
     # repair wheels and write to the location that artifact-uploading code expects to find them
@@ -57,6 +56,4 @@ else
         "${EXCLUDE_ARGS[@]}" \
         -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
         dist/*
-
-    RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 "${package_type}" "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 fi


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/181

Proposes stopping all uploads of wheels and conda packages to `downloads.rapids.ai`, in favor of using the GitHub Actions artifact store.

## Notes for Reviewers

### Intentionally targeting `branch-25.08`

To avoid disrupting the 25.06 release.

### How I found the lines to change

```shell
git grep -E '\-s3'
git grep 'upload'
git grep -E 'downloads\.rapids'
```

### Proposing that `cugraph-gnn` be used to test this pattern for all of RAPIDS

This depends on some `shared-workflows` changes (https://github.com/rapidsai/shared-workflows/pull/364). Proposing the following sequence:

1. merge this PR
2. check that the conda and wheel publishing on the corresponding branch build works
3. check that the conda and wheel publishing on the next nightly build works
4. merge https://github.com/rapidsai/shared-workflows/pull/364 (do not delete its branch though)
5. push a follow-up PR here reverting references to that `gha-artifacts/upload` branch of `shared-workflows`