### PR TITLE
[BUG] Fix Broken DGL Test

### DIFF
--- a/python/cugraph-dgl/cugraph_dgl/tests/test_graph.py
+++ b/python/cugraph-dgl/cugraph_dgl/tests/test_graph.py
@@ -158,9 +158,7 @@ def test_graph_make_heterogeneous_graph(direction, karate_bipartite):
         h_fan_out=np.array([1, 1], dtype="int32"),
         with_replacement=False,
         do_expensive_check=True,
-        with_edge_properties=True,
         prior_sources_behavior="exclude",
-        return_dict=True,
     )
 
     expected_etypes = {

--- a/python/cugraph-dgl/cugraph_dgl/tests/test_graph_mg.py
+++ b/python/cugraph-dgl/cugraph_dgl/tests/test_graph_mg.py
@@ -246,9 +246,7 @@ def run_test_graph_make_heterogeneous_graph_mg(rank, uid, world_size, direction)
         h_fan_out=np.array([-1], dtype="int32"),
         with_replacement=False,
         do_expensive_check=True,
-        with_edge_properties=True,
         prior_sources_behavior="exclude",
-        return_dict=True,
     )
 
     sdf = cudf.DataFrame(


### PR DESCRIPTION
Fixes a broken test in cuGraph-DGL that was calling the old version of the cuGraph sampling API.