### PR TITLE
Remove nvidia and dask channels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
               setup[.]cfg$
       - id: verify-alpha-spec
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.17.0
+    rev: v1.19.0
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -3,9 +3,7 @@
 channels:
 - rapidsai
 - rapidsai-nightly
-- dask/label/dev
 - conda-forge
-- nvidia
 dependencies:
 - breathe
 - cmake>=3.30.4

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -3,9 +3,7 @@
 channels:
 - rapidsai
 - rapidsai-nightly
-- dask/label/dev
 - conda-forge
-- nvidia
 dependencies:
 - breathe
 - cmake>=3.30.4

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -29,7 +29,6 @@ files:
       - test_notebook
       - test_python_common
       - test_python_pylibwholegraph
-
   checks:
     output: none
     includes:
@@ -66,7 +65,6 @@ files:
       - depends_on_cuml
       - py_version
       - test_python_common
-
   test_cugraph_pyg:
     output: none
     includes:
@@ -94,7 +92,6 @@ files:
       - depends_on_mkl
       - depends_on_pylibwholegraph
       - test_python_pylibwholegraph
-
   py_build_libwholegraph:
     output: pyproject
     pyproject_dir: python/libwholegraph
@@ -102,7 +99,6 @@ files:
       table: build-system
     includes:
       - rapids_build_skbuild
-
   py_rapids_build_libwholegraph:
     output: pyproject
     pyproject_dir: python/libwholegraph
@@ -113,7 +109,6 @@ files:
       - common_build
       - depends_on_libraft
       - depends_on_librmm
-
   py_run_libwholegraph:
     output: pyproject
     pyproject_dir: python/libwholegraph
@@ -122,7 +117,6 @@ files:
     includes:
       - depends_on_rapids_logger
       - depends_on_libraft
-
   py_build_pylibwholegraph:
     output: pyproject
     pyproject_dir: python/pylibwholegraph
@@ -130,7 +124,6 @@ files:
       table: build-system
     includes:
       - rapids_build_skbuild
-
   py_rapids_build_pylibwholegraph:
     output: pyproject
     pyproject_dir: python/pylibwholegraph
@@ -143,7 +136,6 @@ files:
       - depends_on_libwholegraph
       - depends_on_libraft
       - depends_on_librmm
-
   py_run_pylibwholegraph:
     output: pyproject
     pyproject_dir: python/pylibwholegraph
@@ -161,7 +153,6 @@ files:
     includes:
       - test_python_common
       - test_python_pylibwholegraph
-
   py_build_cugraph_pyg:
     output: pyproject
     pyproject_dir: python/cugraph-pyg
@@ -192,7 +183,6 @@ files:
       - depends_on_cuml
       - test_python_common
       - test_python_cugraph_pyg
-
   cugraph_pyg_dev:
     matrix:
       cuda: ["12.8"]
@@ -205,13 +195,10 @@ files:
       - depends_on_pyg
       - depends_on_pytorch
       - test_python_common
-
 channels:
   - rapidsai
   - rapidsai-nightly
-  - dask/label/dev
   - conda-forge
-  - nvidia
 dependencies:
   checks:
     common:
@@ -290,7 +277,6 @@ dependencies:
             packages:
               - gcc_linux-aarch64=13.*
               - cuda-nvcc
-
   docs:
     common:
       - output_types: [conda]
@@ -394,7 +380,6 @@ dependencies:
         packages:
           - pytest-forked
           - scipy
-
   depends_on_pytorch:
     common:
       - output_types: [conda]
@@ -417,20 +402,17 @@ dependencies:
             packages:
               - pytorch>=2.3
           - {matrix: null, packages: ["pytorch>=2.3"]}
-
   depends_on_ogb:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
           - ogb
-
   # for MovieLens example
   depends_on_sentence_transformers:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
           - sentence-transformers
-
   depends_on_pyg:
     common:
       - output_types: [conda]
@@ -439,7 +421,6 @@ dependencies:
       - output_types: [pyproject, requirements]
         packages:
           - torch-geometric>=2.5,<2.7
-
   depends_on_pylibwholegraph:
     common:
       - output_types: conda
@@ -459,7 +440,6 @@ dependencies:
             packages:
               - pylibwholegraph-cu12==25.8.*,>=0.0.0a0
           - {matrix: null, packages: [*pylibwholegraph_unsuffixed]}
-
   depends_on_libraft:
     common:
       - output_types: conda
@@ -479,7 +459,6 @@ dependencies:
             packages:
               - libraft-cu12==25.8.*,>=0.0.0a0
           - {matrix: null, packages: [*libraft_unsuffixed]}
-
   depends_on_librmm:
     common:
       - output_types: conda
@@ -500,7 +479,6 @@ dependencies:
             packages:
               - librmm-cu12==25.8.*,>=0.0.0a0
           - {matrix: null, packages: [*librmm_unsuffixed]}
-
   depends_on_rapids_logger:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -510,7 +488,6 @@ dependencies:
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
-
   depends_on_libwholegraph:
     common:
       - output_types: conda
@@ -530,13 +507,11 @@ dependencies:
             packages:
               - libwholegraph-cu12==25.8.*,>=0.0.0a0
           - {matrix: null, packages: [*libwholegraph_unsuffixed]}
-
   depends_on_libwholegraph_tests:
     common:
       - output_types: conda
         packages:
           - libwholegraph-tests==25.8.*,>=0.0.0a0
-
   depends_on_rmm:
     common:
       - output_types: conda
@@ -556,7 +531,6 @@ dependencies:
             packages:
               - rmm-cu12==25.8.*,>=0.0.0a0
           - {matrix: null, packages: [*rmm_unsuffixed]}
-
   depends_on_cugraph:
     common:
       - output_types: conda
@@ -576,7 +550,6 @@ dependencies:
             packages:
               - cugraph-cu12==25.8.*,>=0.0.0a0
           - {matrix: null, packages: [*cugraph_unsuffixed]}
-
   depends_on_cuml:
     common:
       - output_types: conda
@@ -596,7 +569,6 @@ dependencies:
             packages:
               - cuml-cu12==25.8.*,>=0.0.0a0
           - {matrix: null, packages: [*cuml_unsuffixed]}
-
   depends_on_cudf:
     common:
       - output_types: conda
@@ -616,7 +588,6 @@ dependencies:
             packages:
               - cudf-cu12==25.8.*,>=0.0.0a0
           - {matrix: null, packages: [*cudf_unsuffixed]}
-
   depends_on_dask_cudf:
     common:
       - output_types: conda
@@ -636,7 +607,6 @@ dependencies:
             packages:
               - dask-cudf-cu12==25.8.*,>=0.0.0a0
           - {matrix: null, packages: [*dask_cudf_unsuffixed]}
-
   depends_on_pylibcugraph:
     common:
       - output_types: conda
@@ -656,7 +626,6 @@ dependencies:
             packages:
               - pylibcugraph-cu12==25.8.*,>=0.0.0a0
           - {matrix: null, packages: [*pylibcugraph_unsuffixed]}
-
   depends_on_cupy:
     common:
       - output_types: conda

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-128_arch-aarch64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-128_arch-aarch64.yaml
@@ -3,9 +3,7 @@
 channels:
 - rapidsai
 - rapidsai-nightly
-- dask/label/dev
 - conda-forge
-- nvidia
 dependencies:
 - cugraph==25.8.*,>=0.0.0a0
 - pre-commit

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-128_arch-x86_64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-128_arch-x86_64.yaml
@@ -3,9 +3,7 @@
 channels:
 - rapidsai
 - rapidsai-nightly
-- dask/label/dev
 - conda-forge
-- nvidia
 dependencies:
 - cugraph==25.8.*,>=0.0.0a0
 - pre-commit


### PR DESCRIPTION
Now that we have dropped support for CUDA 11 we no longer require the nvidia channel.
With the changes in https://github.com/rapidsai/rapids-dask-dependency/pull/85, RAPIDS now only uses released versions of dask, so we no longer need the dask channel either.
Contributes to https://github.com/rapidsai/build-planning/issues/184
