### PR TITLE
[BUG] Pin CPU Memory Instead of Copying to Device

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/tensor/dist_tensor.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/dist_tensor.py
@@ -267,13 +267,12 @@ class DistTensor:
             The requested node embeddings.
         """
         assert self._tensor is not None, "Please create WholeGraph tensor first."
-        if not idx.is_cuda:
-            idx = idx.pin_memory()
+        idx = idx.cuda()
         if not val.is_cuda:
             val = val.pin_memory()
 
         if val.dtype != self.dtype:
-            val = val.to(self.dtype)
+            val = val.to(self.dtype).pin_memory()
         self._tensor.scatter(val, idx)
 
     def __getitem__(self, idx: "torch.Tensor") -> "torch.Tensor":
@@ -289,8 +288,7 @@ class DistTensor:
             The requested node embeddings.
         """
         assert self._tensor is not None, "Please create WholeGraph tensor first."
-        if not idx.is_cuda:
-            idx = idx.pin_memory()
+        idx = idx.cuda()
         output_tensor = self._tensor.gather(idx)  # output_tensor is on cuda by default
         return output_tensor
 
@@ -504,13 +502,12 @@ class DistEmbedding(DistTensor):
             The requested node embeddings.
         """
         assert self._tensor is not None, "Please create WholeGraph tensor first."
-        if not idx.is_cuda:
-            idx = idx.pin_memory()
+        idx = idx.cuda()
         if not val.is_cuda:
             val = val.pin_memory()
 
         if val.dtype != self.dtype:
-            val = val.to(self.dtype)
+            val = val.to(self.dtype).pin_memory()
         self._embedding.get_embedding_tensor().scatter(val, idx)
 
     def __getitem__(self, idx: "torch.Tensor") -> "torch.Tensor":
@@ -526,8 +523,7 @@ class DistEmbedding(DistTensor):
             The requested node embeddings.
         """
         assert self._tensor is not None, "Please create WholeGraph tensor first."
-        if not idx.is_cuda:
-            idx = idx.pin_memory()
+        idx = idx.cuda()
         output_tensor = self._embedding.gather(
             idx
         )  # output_tensor is on cuda by default

--- a/python/cugraph-pyg/cugraph_pyg/tensor/dist_tensor.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/dist_tensor.py
@@ -268,11 +268,10 @@ class DistTensor:
         """
         assert self._tensor is not None, "Please create WholeGraph tensor first."
         idx = idx.cuda()
+        if val.dtype != self.dtype:
+            val = val.to(self.dtype)
         if not val.is_cuda:
             val = val.pin_memory()
-
-        if val.dtype != self.dtype:
-            val = val.to(self.dtype).pin_memory()
         self._tensor.scatter(val, idx)
 
     def __getitem__(self, idx: "torch.Tensor") -> "torch.Tensor":
@@ -503,11 +502,11 @@ class DistEmbedding(DistTensor):
         """
         assert self._tensor is not None, "Please create WholeGraph tensor first."
         idx = idx.cuda()
+        if val.dtype != self.dtype:
+            val = val.to(self.dtype)
         if not val.is_cuda:
             val = val.pin_memory()
 
-        if val.dtype != self.dtype:
-            val = val.to(self.dtype).pin_memory()
         self._embedding.get_embedding_tensor().scatter(val, idx)
 
     def __getitem__(self, idx: "torch.Tensor") -> "torch.Tensor":

--- a/python/cugraph-pyg/cugraph_pyg/tensor/dist_tensor.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/dist_tensor.py
@@ -267,8 +267,10 @@ class DistTensor:
             The requested node embeddings.
         """
         assert self._tensor is not None, "Please create WholeGraph tensor first."
-        idx = idx.cuda()
-        val = val.cuda()
+        if not idx.is_cuda:
+            idx = idx.pin_memory()
+        if not val.is_cuda:
+            val = val.pin_memory()
 
         if val.dtype != self.dtype:
             val = val.to(self.dtype)
@@ -287,7 +289,8 @@ class DistTensor:
             The requested node embeddings.
         """
         assert self._tensor is not None, "Please create WholeGraph tensor first."
-        idx = idx.cuda()
+        if not idx.is_cuda:
+            idx = idx.pin_memory()
         output_tensor = self._tensor.gather(idx)  # output_tensor is on cuda by default
         return output_tensor
 
@@ -501,8 +504,10 @@ class DistEmbedding(DistTensor):
             The requested node embeddings.
         """
         assert self._tensor is not None, "Please create WholeGraph tensor first."
-        idx = idx.cuda()
-        val = val.cuda()
+        if not idx.is_cuda:
+            idx = idx.pin_memory()
+        if not val.is_cuda:
+            val = val.pin_memory()
 
         if val.dtype != self.dtype:
             val = val.to(self.dtype)
@@ -521,7 +526,8 @@ class DistEmbedding(DistTensor):
             The requested node embeddings.
         """
         assert self._tensor is not None, "Please create WholeGraph tensor first."
-        idx = idx.cuda()
+        if not idx.is_cuda:
+            idx = idx.pin_memory()
         output_tensor = self._embedding.gather(
             idx
         )  # output_tensor is on cuda by default


### PR DESCRIPTION
Pin CPU memory when loading to WholeGraph to avoid copying more data than the GPU can hold.  This was always the intended behavior of WholeGraph tensors - this PR fixes that and resolves this critical bug blocking GraphRAG workflows.