### PR TITLE
remove cugraph-dgl CODEOWNERS rule, skip most CI on CODEOWNERS-only PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,6 @@
 /readme_pages/     @rapidsai/cugraph-doc-codeowners
 
 # python code owners
-python/cugraph-dgl            @rapidsai/cugraph-gnn-python-codeowners
 python/cugraph-pyg            @rapidsai/cugraph-gnn-python-codeowners
 python/pylibwholegraph        @rapidsai/wholegraph-python-codeowners
 mg_utils/          @rapidsai/cugraph-gnn-python-codeowners

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,6 +49,7 @@ jobs:
         test_cpp:
           - '**'
           - '!.devcontainer/**'
+          - '!.github/CODEOWNERS'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/release/update-version.sh'
@@ -60,6 +61,7 @@ jobs:
         test_notebooks:
           - '**'
           - '!.devcontainer/**'
+          - '!.github/CODEOWNERS'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/release/update-version.sh'
@@ -67,6 +69,7 @@ jobs:
         test_python:
           - '**'
           - '!.devcontainer/**'
+          - '!.github/CODEOWNERS'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/release/update-version.sh'


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/203

Follow-up to #210 

* removes a `CODEOWNERS` rule referencing `cugraph-dgl/`
* updates `changed-files` so that future PRs only modifying `CODEOWNERS` won't trigger a full CI run

## Notes for reviewers

Found these like this:

```shell
git grep -i dgl
```