### PR TITLE
[CI] Disable Example Tests

### DIFF
--- a/ci/run_cugraph_pyg_pytests.sh
+++ b/ci/run_cugraph_pyg_pytests.sh
@@ -14,11 +14,11 @@ export CI=true
 # Enable legacy behavior of torch.load for examples relying on ogb
 export TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1
 
-# Test examples (disabled due to excessive network bandwidth usage)
-for e in "$(pwd)"/examples/*.py; do
-  echo "running example $e"
-  (yes || true) | torchrun --nnodes 1 --nproc_per_node 1 $e --dataset_root "${RAPIDS_DATASET_ROOT_DIR}/ogb_datasets"
-done
+# Test examples (disabled due to lack of memory)
+#for e in "$(pwd)"/examples/*.py; do
+#  echo "running example $e"
+#  (yes || true) | torchrun --nnodes 1 --nproc_per_node 1 $e --dataset_root "${RAPIDS_DATASET_ROOT_DIR}/ogb_datasets"
+#done
 
 # echo "running bitcoin example"
 # (yes || true) | torchrun --nnodes 1 --nproc_per_node 1 "$(pwd)"/examples/fraud/bitcoin_mnmg.py --dataset_root "${RAPIDS_DATASET_ROOT_DIR}" --embedding_dir "${RAPIDS_DATASET_ROOT_DIR}/bitcoin_embeddings"

--- a/ci/test_wheel_cugraph-pyg.sh
+++ b/ci/test_wheel_cugraph-pyg.sh
@@ -38,11 +38,11 @@ python -m pytest \
   --benchmark-disable \
   tests
 
-# Test examples
-for e in "$(pwd)"/examples/*.py; do
-  rapids-logger "running example $e"
-  (yes || true) | python -m torch.distributed.run --nnodes 1 --nproc_per_node 1 $e --dataset_root "${RAPIDS_DATASET_ROOT_DIR}/ogb_datasets"
-done
+# Test examples (disabled due to lack of memory)
+#for e in "$(pwd)"/examples/*.py; do
+#  rapids-logger "running example $e"
+#  (yes || true) | python -m torch.distributed.run --nnodes 1 --nproc_per_node 1 $e --dataset_root "${RAPIDS_DATASET_ROOT_DIR}/ogb_datasets"
+#done
 
 # rapids-logger "running bitcoin example"
 # (yes || true) | python -m torch.distributed.run --nnodes 1 --nproc_per_node 1 "$(pwd)"/examples/fraud/bitcoin_mnmg.py --dataset_root "${RAPIDS_DATASET_ROOT_DIR}" --embedding_dir "${RAPIDS_DATASET_ROOT_DIR}/bitcoin_embeddings"


### PR DESCRIPTION
The cuGraph-PyG examples cannot be reliably tested in CI due to memory constraints.  We will need to come up with a new strategy for testing/verifying these examples going forward.