### PR TITLE
cugraph-pyg: remove unnecessary dependency on 'numba'

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -52,7 +52,6 @@ DEPENDENCIES=(
   cugraph-pyg
   cuml
   dask-cuda
-  dask-cudf
   libcudf
   libraft
   libraft-headers
@@ -62,7 +61,6 @@ DEPENDENCIES=(
   pylibcugraph
   pylibwholegraph
   rmm
-  rapids-dask-dependency
 )
 for DEP in "${DEPENDENCIES[@]}"; do
   for FILE in dependencies.yaml conda/environments/*.yaml python/cugraph-pyg/conda/*.yaml; do

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -18,7 +18,6 @@ dependencies:
 - cuml==25.10.*,>=0.0.0a0
 - cupy>=13.2.0
 - cython>=3.0.0
-- dask-cudf==25.10.*,>=0.0.0a0
 - doxygen
 - gcc_linux-aarch64=14.*
 - graphviz

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -18,7 +18,6 @@ dependencies:
 - cuml==25.10.*,>=0.0.0a0
 - cupy>=13.2.0
 - cython>=3.0.0
-- dask-cudf==25.10.*,>=0.0.0a0
 - doxygen
 - gcc_linux-64=14.*
 - graphviz

--- a/conda/recipes/cugraph-pyg/recipe.yaml
+++ b/conda/recipes/cugraph-pyg/recipe.yaml
@@ -30,7 +30,6 @@ requirements:
     - setuptools>=61.0.0
   run:
     - cupy >=13.2.0
-    - numba >=0.57
     - numpy >=1.23,<3.0a0
     - packaging
     - pandas

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -18,7 +18,6 @@ files:
       - depends_on_pylibcugraph
       - depends_on_cugraph
       - depends_on_cudf
-      - depends_on_dask_cudf
       - depends_on_cupy
       - depends_on_cuml
       - depends_on_nccl
@@ -600,25 +599,6 @@ dependencies:
             packages:
               - cudf-cu12==25.10.*,>=0.0.0a0
           - {matrix: null, packages: [*cudf_unsuffixed]}
-  depends_on_dask_cudf:
-    common:
-      - output_types: conda
-        packages:
-          - &dask_cudf_unsuffixed dask-cudf==25.10.*,>=0.0.0a0
-      - output_types: requirements
-        packages:
-          # pip recognizes the index as a global option for the requirements.txt file
-          - --extra-index-url=https://pypi.nvidia.com
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
-    specific:
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
-            packages:
-              - dask-cudf-cu12==25.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*dask_cudf_unsuffixed]}
   depends_on_pylibcugraph:
     common:
       - output_types: conda


### PR DESCRIPTION
Cleaning up some small packaging things I noticed.

* removes `numba` dependency from `cugraph-pyg` conda packages
  - *wheels did not declare one*
  - *there is no direct `numba` usage in `cugraph-pyg` ... `git grep numba`*
* removes some configuration for `dask-cudf` and `rapids-dask-dependency`
  - *most `dask` stuff was removed from this repo in #199, #166, and #168*
  - *the only remaining `dask` stuff is in `cugraph-gnn/mg_utils`: https://github.com/rapidsai/cugraph-gnn/tree/3d4c449e1b08825887e6f8e42605ec0d282ed5a8/mg_utils*