### PR TITLE
build with RAPIDS CUDA architectures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 exclude: '^thirdparty'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: debug-statements
@@ -41,7 +41,7 @@ repos:
         types_or: [c, c++, cuda]
         args: ["-fallback-style=none", "-style=file", "-i"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.4.0
+    rev: v0.7.0
     hooks:
       - id: verify-copyright
         files: |

--- a/build.sh
+++ b/build.sh
@@ -205,11 +205,11 @@ fi
 if hasArg libwholegraph || buildDefault || hasArg all ; then
 
     # set values based on flags
-    if (( ${BUILD_ALL_GPU_ARCH} == 0 )); then
-        WHOLEGRAPH_CMAKE_CUDA_ARCHITECTURES="${WHOLEGRAPH_CMAKE_CUDA_ARCHITECTURES:=NATIVE}"
+    if (( BUILD_ALL_GPU_ARCH == 0 )); then
+        WHOLEGRAPH_CMAKE_CUDA_ARCHITECTURES="NATIVE"
         echo "Building for the architecture of the GPU in the system..."
     else
-        WHOLEGRAPH_CMAKE_CUDA_ARCHITECTURES="70-real;75-real;80-real;86-real;90"
+        WHOLEGRAPH_CMAKE_CUDA_ARCHITECTURES="RAPIDS"
         echo "Building for *ALL* supported GPU architectures..."
     fi
 


### PR DESCRIPTION
While trying to add CUDA 13 builds here, I discovered that this project's `build.sh` script has a hard-coded list of CUDA architectures:

https://github.com/rapidsai/cugraph-gnn/blob/c50d56d0d4987c587e6f377dd4eb9537f3d0440b/build.sh#L212

As described in https://github.com/rapidsai/cugraph-gnn/pull/286#discussion_r2319479909, this proposes removing that hard-coded list in favor of using the `"RAPIDS"` set of architectures from `rapids-cmake`.

This also updates some `pre-commit` hooks versions (unrelated, but low-risk and wanted to take advantage of the CI runs).

## Notes for Reviewers

### Benefits of this change

* keeps this project aligned with the rest of RAPIDS on CUDA architectures
  - reduces the manual effort required to support new CUDA versions
  - avoids the build time and binary size from building for older architectures that RAPIDS no longer supports

### So what architectures will `libwholegraph` now be built for?

```text
# before
70-real;75-real;80-real;86-real;90

# after (CUDA 12)
70-real;75-real;80-real;86-real;90a-real;100f-real;120a-real;120

# after (CUDA 13)
75-real;80-real;86-real;90a-real;100f-real;120a-real;120
```

Those lists come from here: https://github.com/rapidsai/rapids-cmake/blob/0b111489d1e6f8400e1fc88297623a2a9915fa77/rapids-cmake/cuda/set_architectures.cmake