### PR TITLE
[BUG] Fix input type in Taobao example

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/examples/taobao_mnmg.py
+++ b/python/cugraph-pyg/cugraph_pyg/examples/taobao_mnmg.py
@@ -526,7 +526,7 @@ if __name__ == "__main__":
 
         return LinkNeighborLoader(
             data=data_l[0],
-            edge_label_index=edge_label_index,
+            edge_label_index=(("user", "to", "item"), edge_label_index),
             edge_label=edge_label,
             neg_sampling="binary" if edge_label is None else None,
             batch_size=args.batch_size,


### PR DESCRIPTION
The Taobao example does not specify the input type of the edges when creating a `LinkNeighborLoader`, which is invalid since this is a heterogeneous graph.  This PR fixes this by specifying the correct input type, `('user', 'to', 'item')`.