### PR TITLE
[FEA] Enable Temporal Sampling in cuGraph-PyG

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
@@ -80,6 +80,7 @@ class GraphStore(
         self.__graph = None
         self.__vertex_offsets = None
         self.__weight_attr = None
+        self.__etime_attr = None
         self.__numeric_edge_types = None
 
     def _put_edge_index(

--- a/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
@@ -329,13 +329,17 @@ class GraphStore(
 
     def _set_etime_attr(self, attr: Tuple["torch_geometric.data.FeatureStore", str]):
         if attr != self.__etime_attr:
+            weight_attr = self.__weight_attr
             self.__clear_graph()
             self.__etime_attr = attr
+            self.__weight_attr = weight_attr
 
     def _set_weight_attr(self, attr: Tuple["torch_geometric.data.FeatureStore", str]):
         if attr != self.__weight_attr:
+            etime_attr = self.__etime_attr
             self.__clear_graph()
             self.__weight_attr = attr
+            self.__etime_attr = etime_attr
 
     def __get_etime_tensor(
         self,
@@ -352,7 +356,12 @@ class GraphStore(
                 dtype=torch.int64,
                 device="cpu",
             )
-            etimes.append(feature_store[et, attr_name][ix])
+            etime = feature_store[et, attr_name][ix]
+
+            if etime is None:
+                raise ValueError("Time property must be present for all edge types.")
+            etimes.append(etime)
+
         return torch.concat(etimes)
 
     def __get_weight_tensor(

--- a/python/cugraph-pyg/cugraph_pyg/loader/link_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/loader/link_loader.py
@@ -99,9 +99,6 @@ class LinkLoader:
         if not isinstance(link_sampler, cugraph_pyg.sampler.BaseSampler):
             raise NotImplementedError("Must provide a cuGraph sampler")
 
-        if edge_label_time is not None:
-            raise ValueError("Temporal sampling is currently unsupported")
-
         if filter_per_worker:
             warnings.warn("filter_per_worker is currently ignored")
 

--- a/python/cugraph-pyg/cugraph_pyg/loader/link_neighbor_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/loader/link_neighbor_loader.py
@@ -188,6 +188,11 @@ class LinkNeighborLoader(LinkLoader):
             # TODO Confirm that time is an edge attribute
             # TODO Add support for time override (see rapidsai/cugraph#5263)
             graph_store._set_etime_attr((feature_store, time_attr))
+            warnings.warn(
+                "Temporal sampling in cuGraph-PyG is currently only forward in time"
+                " instead of the expected backward in time.  This will be fixed in a"
+                " future release."
+            )
 
         if isinstance(num_neighbors, dict):
             sorted_keys, _, _ = graph_store._numeric_edge_types

--- a/python/cugraph-pyg/cugraph_pyg/loader/neighbor_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/loader/neighbor_loader.py
@@ -151,8 +151,6 @@ class NeighborLoader(NodeLoader):
             warnings.warn("Only the uniform temporal strategy is currently supported")
         if neighbor_sampler is not None:
             raise ValueError("Passing a neighbor sampler is currently unsupported")
-        if time_attr is not None:
-            raise ValueError("Temporal sampling is currently unsupported")
         if is_sorted:
             warnings.warn("The 'is_sorted' argument is ignored by cuGraph.")
         if not isinstance(data, (list, tuple)) or not isinstance(
@@ -174,6 +172,13 @@ class NeighborLoader(NodeLoader):
                 raise ValueError(
                     "Only COO format is supported for heterogeneous graphs!"
                 )
+
+        is_temporal = time_attr is not None
+
+        if is_temporal:
+            # TODO Confirm that time is an edge attribute
+            # TODO Add support for time override (see rapidsai/cugraph#5263)
+            graph_store._set_etime_attr((feature_store, time_attr))
 
         if weight_attr is not None:
             graph_store._set_weight_attr((feature_store, weight_attr))
@@ -208,7 +213,6 @@ class NeighborLoader(NodeLoader):
             (feature_store, graph_store),
             batch_size=batch_size,
         )
-        # TODO add heterogeneous support and pass graph_store._vertex_offsets
 
         super().__init__(
             (feature_store, graph_store),

--- a/python/cugraph-pyg/cugraph_pyg/loader/neighbor_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/loader/neighbor_loader.py
@@ -180,6 +180,12 @@ class NeighborLoader(NodeLoader):
             # TODO Add support for time override (see rapidsai/cugraph#5263)
             graph_store._set_etime_attr((feature_store, time_attr))
 
+            warnings.warn(
+                "Temporal sampling in cuGraph-PyG is currently only forward in time"
+                " instead of the expected backward in time.  This will be fixed in a"
+                " future release."
+            )
+
         if weight_attr is not None:
             graph_store._set_weight_attr((feature_store, weight_attr))
 

--- a/python/cugraph-pyg/cugraph_pyg/loader/neighbor_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/loader/neighbor_loader.py
@@ -207,6 +207,7 @@ class NeighborLoader(NodeLoader):
                 local_seeds_per_call=local_seeds_per_call,
                 biased=(weight_attr is not None),
                 heterogeneous=(not graph_store.is_homogeneous),
+                temporal=is_temporal,
                 vertex_type_offsets=graph_store._vertex_offset_array,
                 num_edge_types=len(graph_store.get_all_edge_attrs()),
             ),

--- a/python/cugraph-pyg/cugraph_pyg/loader/node_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/loader/node_loader.py
@@ -87,9 +87,6 @@ class NodeLoader:
         if not isinstance(node_sampler, cugraph_pyg.sampler.BaseSampler):
             raise NotImplementedError("Must provide a cuGraph sampler")
 
-        if input_time is not None:
-            raise ValueError("Temporal sampling is currently unsupported")
-
         if filter_per_worker:
             warnings.warn("filter_per_worker is currently ignored")
 

--- a/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
+++ b/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
@@ -719,6 +719,11 @@ class DistributedNeighborSampler(BaseDistributedSampler):
                 "Heterogeneous sampling must be selected if there is > 1 edge type."
             )
 
+        print(
+            "?",
+            self.__func == pylibcugraph.heterogeneous_uniform_temporal_neighbor_sample,
+        )
+
         super().__init__(
             graph,
             local_seeds_per_call=self.__calc_local_seeds_per_call(

--- a/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
+++ b/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
@@ -788,6 +788,12 @@ class DistributedNeighborSampler(BaseDistributedSampler):
             "random_state": random_state + rank,
         }
         kwargs.update(self.__func_kwargs)
+
+        from inspect import signature
+
+        print(signature(self.__func))
+
+        print(kwargs)
         sampling_results_dict = self.__func(**kwargs)
 
         sampling_results_dict["fanout"] = cupy.array(self.__fanout, dtype="int32")

--- a/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
+++ b/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
@@ -678,6 +678,10 @@ class DistributedNeighborSampler(BaseDistributedSampler):
         # change.
         # TODO allow func to be a call to a future remote sampling API
         # if the provided graph is in another process (rapidsai/cugraph#4623).
+
+        if temporal:
+            self.__func_kwargs["temporal_property_name"] = "time"
+
         if heterogeneous:
             if vertex_type_offsets is None:
                 raise ValueError("Heterogeneous sampling requires vertex type offsets.")

--- a/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
+++ b/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
@@ -719,11 +719,6 @@ class DistributedNeighborSampler(BaseDistributedSampler):
                 "Heterogeneous sampling must be selected if there is > 1 edge type."
             )
 
-        print(
-            "?",
-            self.__func == pylibcugraph.heterogeneous_uniform_temporal_neighbor_sample,
-        )
-
         super().__init__(
             graph,
             local_seeds_per_call=self.__calc_local_seeds_per_call(
@@ -789,11 +784,6 @@ class DistributedNeighborSampler(BaseDistributedSampler):
         }
         kwargs.update(self.__func_kwargs)
 
-        from inspect import signature
-
-        print(signature(self.__func))
-
-        print(kwargs)
         sampling_results_dict = self.__func(**kwargs)
 
         sampling_results_dict["fanout"] = cupy.array(self.__fanout, dtype="int32")

--- a/python/cugraph-pyg/cugraph_pyg/sampler/sampler.py
+++ b/python/cugraph-pyg/cugraph_pyg/sampler/sampler.py
@@ -209,7 +209,6 @@ class SampleReader:
                 if "label_type_hop_offsets" in self.__raw_sample_data
                 else "label_hop_offsets"
             )
-            print(list(self.__raw_sample_data.keys()))
 
             self.__raw_sample_data["input_offsets"] -= self.__raw_sample_data[
                 "input_offsets"
@@ -368,6 +367,11 @@ class HeterogeneousSampleReader(SampleReader):
                     )
 
             if input_type == pyg_can_etype:
+                # FIXME this is technically not the correct way to calculate the
+                # number of sampled nodes for hop 0, but it should not cause any
+                # issues during training since (presumably) the extra nodes will
+                # get pruned out (rapidsai/cugraph#5270).
+
                 integer_input_type = etype
                 # heterogeneous edges as input, two node types per edge type
                 ux = col[pyg_can_etype][: num_sampled_edges[pyg_can_etype][0]]
@@ -377,6 +381,7 @@ class HeterogeneousSampleReader(SampleReader):
                     if ux.numel() > 0
                     else torch.tensor(0, device=ux.device)
                 )
+
                 num_sampled_nodes[self.__dst_types[etype]][0] = torch.max(
                     num_sampled_nodes[self.__dst_types[etype]][0],
                     uxn.reshape((1,)),
@@ -386,6 +391,7 @@ class HeterogeneousSampleReader(SampleReader):
                     if uy.numel() > 0
                     else torch.tensor(0, device=uy.device)
                 )
+
                 num_sampled_nodes[self.__src_types[etype]][0] = torch.max(
                     num_sampled_nodes[self.__src_types[etype]][0],
                     uyn.reshape((1,)),

--- a/python/cugraph-pyg/cugraph_pyg/sampler/sampler.py
+++ b/python/cugraph-pyg/cugraph_pyg/sampler/sampler.py
@@ -209,6 +209,7 @@ class SampleReader:
                 if "label_type_hop_offsets" in self.__raw_sample_data
                 else "label_hop_offsets"
             )
+            print(list(self.__raw_sample_data.keys()))
 
             self.__raw_sample_data["input_offsets"] -= self.__raw_sample_data[
                 "input_offsets"

--- a/python/cugraph-pyg/cugraph_pyg/tests/loader/test_neighbor_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/loader/test_neighbor_loader.py
@@ -724,6 +724,8 @@ def test_neighbor_loader_temporal_simple(single_pytorch_worker):
 
     feature_store[("paper", "cites", "paper"), "time", None] = tme_cite
 
+    # FIXME the default behavior in PyG should be sampling backward in time
+    # instead of forward.
     # FIXME when input_time is fixed, add another edge to make
     # sure it is properly repected.
     loader = cugraph_pyg.loader.NeighborLoader(

--- a/python/cugraph-pyg/cugraph_pyg/tests/loader/test_neighbor_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/loader/test_neighbor_loader.py
@@ -701,8 +701,9 @@ def test_link_neighbor_loader_hetero_negative_sampling(
 
 
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.parametrize("biased", [True, False])
 @pytest.mark.sg
-def test_neighbor_loader_temporal_simple(single_pytorch_worker):
+def test_neighbor_loader_temporal_simple(single_pytorch_worker, biased):
     """
     Test negative sampling for heterogeneous graphs with different edge types.
     """
@@ -723,6 +724,9 @@ def test_neighbor_loader_temporal_simple(single_pytorch_worker):
     ]
 
     feature_store[("paper", "cites", "paper"), "time", None] = tme_cite
+    feature_store[("paper", "cites", "paper"), "bias", None] = torch.tensor(
+        [1.0] * src_cite.numel(), device="cuda"
+    )
 
     # FIXME the default behavior in PyG should be sampling backward in time
     # instead of forward.
@@ -736,6 +740,7 @@ def test_neighbor_loader_temporal_simple(single_pytorch_worker):
         input_time=torch.tensor([0]),
         time_attr="time",
         shuffle=False,
+        weight_attr="bias" if biased else None,
     )
 
     out = next(iter(loader))
@@ -743,3 +748,69 @@ def test_neighbor_loader_temporal_simple(single_pytorch_worker):
     assert out.e_id.tolist() == [0, 1, 2]
     assert out.num_sampled_nodes.tolist() == [1, 1, 1, 1]
     assert out.num_sampled_edges.tolist() == [1, 1, 1]
+
+
+@pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.parametrize("biased", [True, False])
+@pytest.mark.sg
+def test_neighbor_loader_temporal_simple_hetero(single_pytorch_worker, biased):
+    """
+    Test negative sampling for heterogeneous graphs with different edge types.
+    """
+    # Create a homogeneous graph with paper-paper citations
+    src_cite = torch.tensor([3, 2, 1, 2])  # paper
+    dst_cite = torch.tensor([2, 1, 0, 0])  # paper
+    tme_cite = torch.tensor([0, 1, 2, 0])  # time
+
+    src_author = torch.tensor([3, 2, 2, 1, 3, 2, 0])  # paper
+    dst_author = torch.tensor([0, 0, 1, 1, 2, 2, 2])  # author
+    tme_author = torch.tensor([0, 0, 0, 0, 2, 1, 1])  # time
+
+    num_papers = 4
+    num_authors = 3
+    graph_store = GraphStore()
+    feature_store = FeatureStore()
+
+    # Add paper-paper citations
+    graph_store[("paper", "cites", "paper"), "coo", False, (num_papers, num_papers)] = [
+        dst_cite,
+        src_cite,
+    ]
+
+    graph_store[
+        ("author", "writes", "paper"), "coo", False, (num_authors, num_papers)
+    ] = [
+        dst_author,
+        src_author,
+    ]
+
+    feature_store[("paper", "cites", "paper"), "time", None] = tme_cite
+    feature_store[("author", "writes", "paper"), "time", None] = tme_author
+
+    feature_store[("paper", "cites", "paper"), "bias", None] = torch.tensor(
+        [1.0] * src_cite.numel(), device="cuda"
+    )
+    feature_store[("author", "writes", "paper"), "bias", None] = torch.tensor(
+        [1.0] * src_author.numel(), device="cuda"
+    )
+
+    # FIXME the default behavior in PyG should be sampling backward in time
+    # instead of forward.
+    # FIXME when input_time is fixed, add another edge to make
+    # sure it is properly repected.
+    loader = cugraph_pyg.loader.NeighborLoader(
+        (feature_store, graph_store),
+        num_neighbors={
+            ("paper", "cites", "paper"): [2, 2, 2],
+            ("author", "writes", "paper"): [2, 1, 0],
+        },
+        batch_size=1,
+        input_nodes=("paper", torch.tensor([3])),
+        input_time=torch.tensor([0]),
+        time_attr="time",
+        weight_attr="bias" if biased else None,
+        shuffle=False,
+    )
+
+    out = next(iter(loader))
+    print(out)


### PR DESCRIPTION
Enables temporal sampling in cuGraph-PyG with some constraints:
1. Only supports sampling forward in time (probably an API violation)
2. Does not support time overrides (definitely an API violation)

Closes #116 