### PR TITLE
fix condition to skip CUDA 13 conda-python-tests jobs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -143,7 +143,7 @@ jobs:
       build_type: pull-request
       # TODO: remove the CUDA 13 exclusion here once there are pytorch CUDA 13 packages
       #  ref: https://github.com/pytorch/pytorch/issues/159779
-      matrix_filter: map(select(.ARCH == "amd64" and .CUDA_VER != "13.0.0" ))
+      matrix_filter: map(select(.ARCH == "amd64" and (!.CUDA_VER | startswith("13")))
       script: ci/test_python.sh
   docs-build:
     needs: conda-cpp-build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -143,7 +143,7 @@ jobs:
       build_type: pull-request
       # TODO: remove the CUDA 13 exclusion here once there are pytorch CUDA 13 packages
       #  ref: https://github.com/pytorch/pytorch/issues/159779
-      matrix_filter: map(select(.ARCH == "amd64" and (!.CUDA_VER | startswith("13")))
+      matrix_filter: map(select(.ARCH == "amd64" and (.CUDA_VER | startswith("12"))))
       script: ci/test_python.sh
   docs-build:
     needs: conda-cpp-build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
       sha: ${{ inputs.sha }}
       # TODO: remove the CUDA 13 exclusion here once there are pytorch CUDA 13 packages
       #  ref: https://github.com/pytorch/pytorch/issues/159779
-      matrix_filter: map(select(.ARCH == "amd64" and (!.CUDA_VER | startswith("13")))
+      matrix_filter: map(select(.ARCH == "amd64" and (.CUDA_VER | startswith("12"))))
   wheel-tests-pylibwholegraph:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.10

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
       sha: ${{ inputs.sha }}
       # TODO: remove the CUDA 13 exclusion here once there are pytorch CUDA 13 packages
       #  ref: https://github.com/pytorch/pytorch/issues/159779
-      matrix_filter: map(select(.ARCH == "amd64" and .CUDA_VER != "13.0.0" ))
+      matrix_filter: map(select(.ARCH == "amd64" and (!.CUDA_VER | startswith("13")))
   wheel-tests-pylibwholegraph:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.10


### PR DESCRIPTION
RAPIDS recently started building and testing against CUDA 13.0.1:

* https://github.com/rapidsai/ci-imgs/pull/304
* https://github.com/rapidsai/shared-workflows/pull/423

This makes the "skip `conda-python-tests` jobs on CUDA 13" condition in CI configs a bit more generic, so we won't start picking up CUDA 13.0.1 jobs when this project isn't yet ready for them (#296).