### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -278,10 +278,6 @@ dependencies:
       - output_types: [conda]
         matrices:
           - matrix:
-              py: "3.10"
-            packages:
-              - python=3.10
-          - matrix:
               py: "3.11"
             packages:
               - python=3.11
@@ -295,7 +291,7 @@ dependencies:
               - python=3.13
           - matrix:
             packages:
-              - python>=3.10,<3.14
+              - python>=3.11,<3.14
   python_build_cythonize:
     common:
       - output_types: [conda, pyproject, requirements]

--- a/python/cugraph-pyg/pyproject.toml
+++ b/python/cugraph-pyg/pyproject.toml
@@ -23,11 +23,10 @@ authors = [
 ]
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/python/libwholegraph/pyproject.toml
+++ b/python/libwholegraph/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Database",

--- a/python/pylibwholegraph/pyproject.toml
+++ b/python/pylibwholegraph/pyproject.toml
@@ -17,11 +17,10 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/246

Finishes the work of dropping Python 3.10 support.

This project stopped building / testing against Python 3.10 as of https://github.com/rapidsai/shared-workflows/pull/494
This PR updates configuration and docs to reflect that.

## Followups before merging

Check that there are no remaining uses like this:

```shell
git grep -E '3\.10'
git grep '310'
git grep 'py310'
```
