### PR TITLE
Use PyTorch CUDA 13 builds in CUDA 13 jobs

### DIFF
--- a/ci/test_wheel_pylibwholegraph.sh
+++ b/ci/test_wheel_pylibwholegraph.sh
@@ -31,7 +31,7 @@ mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-logger "Installing Packages"
 rapids-pip-retry install \
-    --extra-index-url ${PYTORCH_INDEX_URL} \
+    --extra-index-url ${PYTORCH_INDEX} \
     "$(echo "${PYLIBWHOLEGRAPH_WHEELHOUSE}"/pylibwholegraph*.whl)[test]" \
     "${LIBWHOLEGRAPH_WHEELHOUSE}"/*.whl \
     'torch>=2.3'


### PR DESCRIPTION
This fixes an issue observed in https://github.com/rapidsai/cugraph-gnn/pull/403.

We need to use the CUDA 13.0 PyTorch wheels when testing on CUDA 13.
