### PR TITLE
chore(greptile): add basic config file

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,6 +1,6 @@
 {
   "shouldUpdateDescription": false,
   "includeSequenceDiagram": false,
-  "instructions": "Provide concise, direct code reviews. Focus on substantive issues only. Avoid excessive praise or apologies. Be brief and to the point."
+  "instructions": "Provide concise, direct code reviews. Focus on substantive issues only. Avoid excessive praise or apologies. Be brief and to the point.",
   "comment": "Greptile code reviews should be reviewed for accuracy and completeness. Please remember to give Greptile feedback (👍/👎) and consider leaving comments explaining why Greptile's feedback was helpful or not. This will help improve future code reviews."
 }


### PR DESCRIPTION
Adding a _very_ basic greptile config file.

My understanding is that these config options override the UI-based config.

The changes here are to:
- Turn off those useless sequence diagrams
- Make it never edit the PR description
- Try to make it be less annoying language-wise (this will undoubtedly fail)
