### PR TITLE
[BUG] Fix Weights Issue in Negative Sampling

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/sampler/sampler_utils.py
+++ b/python/cugraph-pyg/cugraph_pyg/sampler/sampler_utils.py
@@ -166,10 +166,16 @@ def neg_sample(
             )
 
             src_weight = torch.concat(
-                [src_weight, torch.zeros(num_dst_nodes, dtype=weight_dtype, device="cuda")]
+                [
+                    src_weight,
+                    torch.zeros(num_dst_nodes, dtype=weight_dtype, device="cuda"),
+                ]
             )
             dst_weight = torch.concat(
-                [torch.zeros(num_src_nodes, dtype=weight_dtype, device="cuda"), dst_weight]
+                [
+                    torch.zeros(num_src_nodes, dtype=weight_dtype, device="cuda"),
+                    dst_weight,
+                ]
             )
         else:
             vertices = (
@@ -177,8 +183,6 @@ def neg_sample(
                 + graph_store._vertex_offsets[input_type[0]]
             )
 
-    elif src_weight is None and dst_weight is None:
-        vertices = None
     else:
         vertices = torch.arange(num_src_nodes, dtype=torch.int64, device="cuda")
 

--- a/python/cugraph-pyg/cugraph_pyg/sampler/sampler_utils.py
+++ b/python/cugraph-pyg/cugraph_pyg/sampler/sampler_utils.py
@@ -164,18 +164,19 @@ def neg_sample(
                     + graph_store._vertex_offsets[input_type[2]],
                 ]
             )
+
+            src_weight = torch.concat(
+                [src_weight, torch.zeros(num_dst_nodes, dtype=weight_dtype, device="cuda")]
+            )
+            dst_weight = torch.concat(
+                [torch.zeros(num_src_nodes, dtype=weight_dtype, device="cuda"), dst_weight]
+            )
         else:
             vertices = (
                 torch.arange(num_src_nodes, dtype=torch.int64, device="cuda")
                 + graph_store._vertex_offsets[input_type[0]]
             )
 
-        src_weight = torch.concat(
-            [src_weight, torch.zeros(num_dst_nodes, dtype=weight_dtype, device="cuda")]
-        )
-        dst_weight = torch.concat(
-            [torch.zeros(num_src_nodes, dtype=weight_dtype, device="cuda"), dst_weight]
-        )
     elif src_weight is None and dst_weight is None:
         vertices = None
     else:


### PR DESCRIPTION
Fixes an issue in negative sampling where the weights array was extended in the src=dst case, which is incorrect since the original arrays were already full.