### PR TITLE
Update to clang 20.1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
           (?x)
             python/pylibwholegraph/pylibwholegraph/_doctor_check[.]py$
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v20.1.4
+    rev: v20.1.8
     hooks:
       - id: clang-format
         types_or: [c, c++, cuda]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/267

This PR updates the clang version to 20.1.8.
