### PR TITLE
Update Matrix Filters to Enable Python 3.14 Tests and Disable 12.2 Tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -213,7 +213,8 @@ jobs:
       build_type: pull-request
       # There aren't pytorch-gpu aarch64 packages with CUDA 12.2 support, so skip (arm64, CUDA 12.2) but
       # otherwise run all jobs.
-      matrix_filter: map(select(.PY_VER != "3.14")) | map(select((.ARCH == "amd64") or ((.ARCH == "arm64") and (.CUDA_VER != "12.2.2"))))
+      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
+      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))
       script: ci/test_python.sh
   docs-build:
     needs: [conda-cpp-build, changed-files]
@@ -257,7 +258,8 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_pylibwholegraph.sh
-      matrix_filter: map(select(.PY_VER != "3.14"))
+      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
+      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))
   wheel-build-cugraph-pyg:
     needs: checks
     secrets: inherit
@@ -279,4 +281,5 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_cugraph-pyg.sh
-      matrix_filter: map(select(.PY_VER != "3.14"))
+      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
+      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -214,7 +214,7 @@ jobs:
       # There aren't pytorch-gpu aarch64 packages with CUDA 12.2 support, so skip (arm64, CUDA 12.2) but
       # otherwise run all jobs.
       # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))
+      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))
       script: ci/test_python.sh
   docs-build:
     needs: [conda-cpp-build, changed-files]
@@ -259,7 +259,7 @@ jobs:
       build_type: pull-request
       script: ci/test_wheel_pylibwholegraph.sh
       # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))
+      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))
   wheel-build-cugraph-pyg:
     needs: checks
     secrets: inherit
@@ -282,4 +282,4 @@ jobs:
       build_type: pull-request
       script: ci/test_wheel_cugraph-pyg.sh
       # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))
+      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
       # There aren't pytorch-gpu aarch64 packages with CUDA 12.2 support, so skip (arm64, CUDA 12.2) but
       # otherwise run all jobs.
       # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))
+      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))
   wheel-tests-pylibwholegraph:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
@@ -55,7 +55,7 @@ jobs:
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_pylibwholegraph.sh
       # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))
+      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))
   wheel-tests-cugraph-pyg:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
@@ -66,4 +66,4 @@ jobs:
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_cugraph-pyg.sh
       # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))
+      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,8 @@ jobs:
       sha: ${{ inputs.sha }}
       # There aren't pytorch-gpu aarch64 packages with CUDA 12.2 support, so skip (arm64, CUDA 12.2) but
       # otherwise run all jobs.
-      matrix_filter: map(select(.PY_VER != "3.14")) | map(select((.ARCH == "amd64") or ((.ARCH == "arm64") and (.CUDA_VER != "12.2.2"))))
+      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
+      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))
   wheel-tests-pylibwholegraph:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
@@ -53,7 +54,8 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_pylibwholegraph.sh
-      matrix_filter: map(select(.PY_VER != "3.14"))
+      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
+      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))
   wheel-tests-cugraph-pyg:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
@@ -63,4 +65,5 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_cugraph-pyg.sh
-      matrix_filter: map(select(.PY_VER != "3.14"))
+      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
+      matrix_filter: (map(select((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0"))))


### PR DESCRIPTION
Update the matrix filters to test on Python 3.14 and temporarily disable 12.2 tests, and any other potential tests on CUDA < 12.9, until the issues with cuGraph are resolved.