### PR TITLE
Re-enable CUDA 12.2 and Python 3.14 tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,7 +122,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.2.0
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.PY_VER != "3.14")) | map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -247,7 +247,7 @@ jobs:
       build_type: pull-request
       # There aren't pytorch-gpu aarch64 packages with CUDA 12.2 support, so skip (arm64, CUDA 12.2) but
       # otherwise run all jobs.
-      matrix_filter: map(select(.PY_VER != "3.14")) | map(select((.ARCH == "amd64") or ((.ARCH == "arm64") and (.CUDA_VER != "12.2.2"))))
+      matrix_filter: map(select((.ARCH == "amd64") or ((.ARCH == "arm64") and (.CUDA_VER != "12.2.2"))))
       script: ci/test_python.sh
     permissions:
       actions: read
@@ -315,7 +315,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_pylibwholegraph.sh
-      matrix_filter: map(select(.PY_VER != "3.14"))
     permissions:
       actions: read
       contents: read
@@ -328,7 +327,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@cuda-13.2.0
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
-      matrix_filter: map(select(.PY_VER != "3.14")) | map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
       build_type: pull-request
       node_type: cpu4
       script: ci/build_wheel_cugraph-pyg.sh
@@ -349,7 +348,6 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_cugraph-pyg.sh
-      matrix_filter: map(select(.PY_VER != "3.14"))
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -247,8 +247,7 @@ jobs:
       build_type: pull-request
       # There aren't pytorch-gpu aarch64 packages with CUDA 12.2 support, so skip (arm64, CUDA 12.2) but
       # otherwise run all jobs.
-      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))
+      matrix_filter: map(select(.PY_VER != "3.14")) | map(select((.ARCH == "amd64") or ((.ARCH == "arm64") and (.CUDA_VER != "12.2.2"))))
       script: ci/test_python.sh
     permissions:
       actions: read
@@ -316,8 +315,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_pylibwholegraph.sh
-      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))
+      matrix_filter: map(select(.PY_VER != "3.14"))
     permissions:
       actions: read
       contents: read
@@ -351,8 +349,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel_cugraph-pyg.sh
-      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))
+      matrix_filter: map(select(.PY_VER != "3.14"))
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,8 +48,7 @@ jobs:
       sha: ${{ inputs.sha }}
       # There aren't pytorch-gpu aarch64 packages with CUDA 12.2 support, so skip (arm64, CUDA 12.2) but
       # otherwise run all jobs.
-      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))
+      matrix_filter: map(select(.PY_VER != "3.14")) | map(select((.ARCH == "amd64") or ((.ARCH == "arm64") and (.CUDA_VER != "12.2.2"))))
     permissions:
       actions: read
       contents: read
@@ -65,8 +64,7 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_pylibwholegraph.sh
-      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))
+      matrix_filter: map(select(.PY_VER != "3.14"))
     permissions:
       actions: read
       contents: read
@@ -82,8 +80,7 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_cugraph-pyg.sh
-      # Temporarily skip tests for CUDA versions older than 12.9 until the cuGraph issues are resolved.
-      matrix_filter: (map(select(((.ARCH == "amd64") and (.CUDA_VER >= "12.9.0")) or ((.ARCH == "arm64") and (.CUDA_VER >= "12.9.0")))))
+      matrix_filter: map(select(.PY_VER != "3.14"))
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
       sha: ${{ inputs.sha }}
       # There aren't pytorch-gpu aarch64 packages with CUDA 12.2 support, so skip (arm64, CUDA 12.2) but
       # otherwise run all jobs.
-      matrix_filter: map(select(.PY_VER != "3.14")) | map(select((.ARCH == "amd64") or ((.ARCH == "arm64") and (.CUDA_VER != "12.2.2"))))
+      matrix_filter: map(select((.ARCH == "amd64") or ((.ARCH == "arm64") and (.CUDA_VER != "12.2.2"))))
     permissions:
       actions: read
       contents: read
@@ -64,7 +64,6 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_pylibwholegraph.sh
-      matrix_filter: map(select(.PY_VER != "3.14"))
     permissions:
       actions: read
       contents: read
@@ -80,7 +79,6 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_cugraph-pyg.sh
-      matrix_filter: map(select(.PY_VER != "3.14"))
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Summary
- restore CUDA 12.2 test matrix coverage removed in https://github.com/rapidsai/cugraph-gnn/pull/454
- restore Python 3.14 CI coverage removed in https://github.com/rapidsai/cugraph-gnn/pull/433
- keep the existing arm64 CUDA 12.2 exclusion
- follows the CUDA 12.2 runtime fix from https://github.com/rapidsai/cugraph/pull/5499