### PR TITLE
Explicitly support bf16 in feature store

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
@@ -94,6 +94,7 @@ class FeatureStore(
             (torch.int16, 4),
             (torch.float16, 5),
             (torch.int8, 6),
+            (torch.bfloat16, 7),
         ]:
             dtypes[k] = v
             dtype_ids[v] = k

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
@@ -62,6 +62,7 @@ def test_feature_store_basic_api(single_pytorch_worker):
         "int32",
         "int64",
         "float64",
+        "bfloat16",
     ],
 )
 def test_feature_store_basic_api_types(single_pytorch_worker, dtype_name, torch):

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store_mg.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store_mg.py
@@ -15,10 +15,7 @@ pylibwholegraph = import_optional("pylibwholegraph")
 
 
 def run_test_wholegraph_feature_store_basic_api(rank, world_size, dtype):
-    if dtype == "float32":
-        torch_dtype = torch.float32
-    elif dtype == "int64":
-        torch_dtype = torch.int64
+    torch_dtype = getattr(torch, dtype)
 
     torch.cuda.set_device(rank)
 

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store_mg.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store_mg.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -47,7 +47,10 @@ def run_test_wholegraph_feature_store_basic_api(rank, world_size, dtype):
     isinstance(pylibwholegraph, MissingModule), reason="wholegraph not available"
 )
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
-@pytest.mark.parametrize("dtype", ["float32", "int64"])
+@pytest.mark.parametrize(
+    "dtype",
+    ["float32", "int64", "float16", "int8", "int16", "int32", "float64", "bfloat16"],
+)
 @pytest.mark.mg
 def test_wholegraph_feature_store_basic_api(dtype):
     world_size = torch.cuda.device_count()


### PR DESCRIPTION
Adds explicit support for bfloat16 in `cugraph_pyg.data.FeatureStore`