### PR TITLE
skip CuPy 14.1.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cudf==26.6.*,>=0.0.0a0
 - cugraph==26.6.*,>=0.0.0a0
 - cuml==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cython>=3.2.2
 - doxygen
 - gcc_linux-aarch64=14.*

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cudf==26.6.*,>=0.0.0a0
 - cugraph==26.6.*,>=0.0.0a0
 - cuml==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cython>=3.2.2
 - doxygen
 - gcc_linux-64=14.*

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cudf==26.6.*,>=0.0.0a0
 - cugraph==26.6.*,>=0.0.0a0
 - cuml==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cython>=3.2.2
 - doxygen
 - gcc_linux-aarch64=14.*

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cudf==26.6.*,>=0.0.0a0
 - cugraph==26.6.*,>=0.0.0a0
 - cuml==26.6.*,>=0.0.0a0
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cython>=3.2.2
 - doxygen
 - gcc_linux-64=14.*

--- a/conda/recipes/cugraph-pyg/recipe.yaml
+++ b/conda/recipes/cugraph-pyg/recipe.yaml
@@ -30,7 +30,7 @@ requirements:
     - rapids-build-backend >=0.4.0,<0.5.0
     - setuptools>=77.0.0
   run:
-    - cupy >=13.6.0
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
     - numpy >=1.23,<3.0
     - pandas
     - pylibcugraph =${{ minor_version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -765,7 +765,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - cupy>=13.6.0
+          - cupy>=13.6.0,!=14.0.0,!=14.1.0
     # NOTE: This is intentionally not broken into groups by a 'cuda_suffixed' selector like
     #       other packages with -cu{nn}x suffixes in this file.
     #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
@@ -775,11 +775,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0
+              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0
+              - cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
   depends_on_cugraph_pyg:
     common:
       - output_types: conda

--- a/python/cugraph-pyg/pyproject.toml
+++ b/python/cugraph-pyg/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "cupy-cuda13x>=13.6.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "numpy>=1.23,<3.0",
     "pandas",
     "pylibcugraph==26.6.*,>=0.0.0a0",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/284

Fixes #468

Replaces #469

To reduce the risk of users encountering a known runtime issue with `cupy` and `torch`, RAPIDS 26.06 is taking on a requirement `cupy!=14.1.0`.

See the linked issue for details.
