### PR TITLE
Pin CMake to < 4.4

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - breathe
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-nvcc
 - cuda-nvml-dev
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - breathe
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-nvcc
 - cuda-nvml-dev
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - breathe
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-nvcc
 - cuda-nvml-dev
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 dependencies:
 - breathe
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-nvcc
 - cuda-nvml-dev
 - cuda-nvtx-dev

--- a/conda/recipes/libwholegraph/conda_build_config.yaml
+++ b/conda/recipes/libwholegraph/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - cuda-nvcc
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 doxygen_version:
   - ">=1.8.11"

--- a/conda/recipes/pylibwholegraph/conda_build_config.yaml
+++ b/conda/recipes/pylibwholegraph/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - cuda-nvcc
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 scikit_build_core_version:
   - ">=0.10.0"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -303,7 +303,7 @@ dependencies:
     common:
       - output_types: [conda, pyproject, requirements]
         packages:
-          - &cmake_ver cmake>=4.0
+          - &cmake_ver cmake>=4.0,<4.4
           - ninja
       - output_types: [conda]
         packages:

--- a/python/libwholegraph/pyproject.toml
+++ b/python/libwholegraph/pyproject.toml
@@ -64,7 +64,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "libraft==26.8.*,>=0.0.0a0",
     "librmm==26.8.*,>=0.0.0a0",
     "ninja",

--- a/python/pylibwholegraph/pyproject.toml
+++ b/python/pylibwholegraph/pyproject.toml
@@ -49,7 +49,7 @@ build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
 matrix-entry = "cuda_suffixed=true"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "cython>=3.2.2",
     "libraft==26.8.*,>=0.0.0a0",
     "librmm==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

rapids-cmake is currently broken by CMake 4.4, so pin CMake until we have a fix.

Issue: https://github.com/rapidsai/build-planning/issues/302
