### PR TITLE
Add transpose support for distributed matrices

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
@@ -37,6 +37,11 @@ class FeatureStore(
     get_tensor, multi_get_tensor, etc., the entire tensor can be accessed
     regardless of what worker's partition the desired slice of the tensor
     is on.
+
+    When a :class:`~cugraph_pyg.tensor.DistTensor` is passed to
+    ``put_tensor`` without an index, it is stored by reference and its data is
+    not copied. Subsequent changes to the distributed tensor are therefore
+    visible to the store. Indexed insertion of a DistTensor is not supported.
     """
 
     def __init__(self, memory_type=None, location="cpu"):
@@ -185,6 +190,15 @@ class FeatureStore(
         tensor: "torch_geometric.typing.FeatureTensorType",
         attr: "torch_geometric.data.feature_store.TensorAttr",
     ) -> bool:
+        if isinstance(tensor, DistTensor):
+            if attr.is_set("index") and attr.index is not None:
+                raise ValueError(
+                    "An index cannot be specified when storing a DistTensor "
+                    "by reference"
+                )
+            self.__features[(attr.group_name, attr.attr_name)] = tensor
+            return True
+
         if attr.is_set("index") and attr.index is not None:
             if (attr.group_name, attr.attr_name) not in self.__features:
                 self.__features[(attr.group_name, attr.attr_name)] = (

--- a/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
@@ -108,7 +108,9 @@ class GraphStore(
 
         if isinstance(edge_index, DistMatrix):
             if edge_index._format != "coo":
-                raise ValueError("Only COO format supported")
+                raise ValueError(
+                    "Only COO format is supported when passing a DistMatrix."
+                )
 
             self.__edge_indices[edge_attr.edge_type] = edge_index
             self.__sizes[edge_attr.edge_type] = edge_attr.size
@@ -125,8 +127,8 @@ class GraphStore(
         ):
             if edge_index[0].shape[0] != edge_index[1].shape[0]:
                 raise ValueError(
-                    "Only COO format is supported for construction "
-                    "from DistTensor tuples."
+                    "GraphStore currently only supports COO format, "
+                    "which requires that the two tensors have the same number of elements."
                 )
 
             dist_matrix = DistMatrix(

--- a/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
@@ -51,6 +51,13 @@ class GraphStore(
 
     Each worker should have a slice of the graph locally, and
     call put_edge_index with its slice.
+
+    When a COO :class:`~cugraph_pyg.tensor.DistMatrix` is passed to
+    ``put_edge_index``, it is stored by reference and its data is not copied.
+    Likewise, when a pair of :class:`~cugraph_pyg.tensor.DistTensor` objects
+    is passed, the resulting matrix retains references to those tensors.
+    Subsequent changes to these distributed objects are therefore visible to
+    the store.
     """
 
     def __init__(self, location="cpu"):
@@ -99,6 +106,41 @@ class GraphStore(
         if edge_attr.layout != torch_geometric.data.graph_store.EdgeLayout.COO:
             raise ValueError("Only COO format supported")
 
+        if isinstance(edge_index, DistMatrix):
+            if edge_index._format != "coo":
+                raise ValueError("Only COO format supported")
+
+            self.__edge_indices[edge_attr.edge_type] = edge_index
+            self.__sizes[edge_attr.edge_type] = edge_attr.size
+
+            # invalidate the graph
+            self.__clear_graph()
+            return True
+
+        if (
+            isinstance(edge_index, (tuple, list))
+            and len(edge_index) == 2
+            and isinstance(edge_index[0], DistTensor)
+            and isinstance(edge_index[1], DistTensor)
+        ):
+            if edge_index[0].shape[0] != edge_index[1].shape[0]:
+                raise ValueError(
+                    "Only COO format is supported for construction "
+                    "from DistTensor tuples."
+                )
+
+            dist_matrix = DistMatrix(
+                src=(edge_index[1], edge_index[0]),
+                backend=self.__backend,
+                format="coo",
+            )
+            self.__edge_indices[edge_attr.edge_type] = dist_matrix
+            self.__sizes[edge_attr.edge_type] = edge_attr.size
+
+            # invalidate the graph
+            self.__clear_graph()
+            return True
+
         if isinstance(edge_index, (cupy.ndarray, cudf.Series)):
             edge_index = torch.as_tensor(edge_index, device="cuda")
         elif isinstance(edge_index, (np.ndarray)):
@@ -128,32 +170,18 @@ class GraphStore(
 
         offset = sizes[:rank].sum() if rank > 0 else 0
 
-        if isinstance(edge_index, DistMatrix):
-            self.__edge_indices[edge_attr.edge_type] = edge_index
-        else:
-            self.__edge_indices[edge_attr.edge_type] = DistMatrix(
-                shape=(size, size),
-                dtype=torch.long,
-                device=self.__wg_location,
-                backend=self.__backend,
-            )
+        self.__edge_indices[edge_attr.edge_type] = DistMatrix(
+            shape=(size, size),
+            dtype=torch.long,
+            device=self.__wg_location,
+            backend=self.__backend,
+        )
 
-            if isinstance(edge_index[0], DistTensor) and isinstance(
-                edge_index[1], DistTensor
-            ):
-                if edge_index[0].shape[0] != edge_index[1].shape[0]:
-                    raise ValueError(
-                        "Only COO format is supported for construction "
-                        "from DistTensor tuples."
-                    )
-                self.__edge_indices[edge_attr.edge_type]._row = edge_index[0]
-                self.__edge_indices[edge_attr.edge_type]._col = edge_index[1]
-            else:
-                if isinstance(edge_index, list):
-                    edge_index = torch.stack(edge_index)
-                self.__edge_indices[edge_attr.edge_type][
-                    offset : offset + local_size
-                ] = edge_index
+        if isinstance(edge_index, list):
+            edge_index = torch.stack(edge_index)
+        self.__edge_indices[edge_attr.edge_type][offset : offset + local_size] = (
+            edge_index
+        )
 
         self.__sizes[edge_attr.edge_type] = edge_attr.size
 

--- a/python/cugraph-pyg/cugraph_pyg/tensor/dist_matrix.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/dist_matrix.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Optional, Union, Tuple, List, Literal
@@ -28,19 +28,26 @@ class DistMatrix:
         dtype: Optional["torch.dtype"] = None,
         device: Optional[Literal["cpu", "cuda"]] = "cpu",
         backend: Optional[Literal["nccl", "vmm"]] = "nccl",
-        format: Optional[Literal["csc", "coo"]] = "coo",
+        format: Optional[Literal["csr", "csc", "coo"]] = "coo",
     ):
         self.__backend = backend
         self._format = format
 
         if isinstance(src, (tuple, list)):
+            if len(src) != 2:
+                raise ValueError("src must be a tuple of two tensors")
             if isinstance(src[0], str):
                 raise NotImplementedError(
                     "Constructing from a file or list of files is not yet supported."
                 )
+            elif isinstance(src[0], DistTensor) and isinstance(src[1], DistTensor):
+                self._col = src[0]
+                self._row = src[1]
+            elif isinstance(src[0], DistTensor) or isinstance(src[1], DistTensor):
+                raise ValueError(
+                    "src must contain either two DistTensor objects or two tensors"
+                )
             else:
-                if len(src) != 2:
-                    raise ValueError("src must be a tuple of two tensors")
                 self._col = DistTensor(
                     src=src[0], device=device, dtype=(dtype or src[0].dtype)
                 )
@@ -48,12 +55,12 @@ class DistMatrix:
                     src=src[1], device=device, dtype=(dtype or src[1].dtype)
                 )
 
-                if self._format == "coo":
-                    if self._col.shape[0] != self._row.shape[0]:
-                        raise ValueError(
-                            "col and row must have the same number of "
-                            "elements for COO format"
-                        )
+            if self._format == "coo":
+                if self._col.shape[0] != self._row.shape[0]:
+                    raise ValueError(
+                        "col and row must have the same number of "
+                        "elements for COO format"
+                    )
         elif src is None:
             if dtype is None or shape is None:
                 raise ValueError("dtype and shape must be provided if src is None")
@@ -116,6 +123,49 @@ class DistMatrix:
 
     def get_local_tensor(self) -> Tuple["torch.Tensor", "torch.Tensor"]:
         return (self._col.get_local_tensor(), self._row.get_local_tensor())
+
+    def transpose(self, view: bool = False) -> "DistMatrix":
+        """Return the transpose of this matrix.
+
+        Parameters
+        ----------
+        view : bool, optional
+            If ``True``, return a view that shares the underlying distributed
+            tensors with this matrix. If ``False``, copy the distributed
+            tensors.
+
+        Returns
+        -------
+        DistMatrix
+            A matrix whose column and row tensors are reversed.
+        """
+        transposed = self.__class__.__new__(self.__class__)
+        transposed.__backend = self.__backend
+        transposed._format = {
+            "csr": "csc",
+            "csc": "csr",
+        }.get(self._format, self._format)
+
+        if view:
+            transposed._col = self._row
+            transposed._row = self._col
+        else:
+            transposed._col = DistTensor(
+                shape=self._row.shape,
+                dtype=self._row.dtype,
+                device=self._row.device,
+                backend=self.__backend,
+            )
+            transposed._row = DistTensor(
+                shape=self._col.shape,
+                dtype=self._col.dtype,
+                device=self._col.device,
+                backend=self.__backend,
+            )
+            transposed._col.get_local_tensor().copy_(self._row.get_local_tensor())
+            transposed._row.get_local_tensor().copy_(self._col.get_local_tensor())
+
+        return transposed
 
     @property
     def local_col(self) -> "torch.Tensor":

--- a/python/cugraph-pyg/cugraph_pyg/tensor/dist_matrix.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/dist_matrix.py
@@ -154,16 +154,24 @@ class DistMatrix:
                 shape=self._row.shape,
                 dtype=self._row.dtype,
                 device=self._row.device,
+                partition_book=self._row.partition_book,
                 backend=self.__backend,
             )
             transposed._row = DistTensor(
                 shape=self._col.shape,
                 dtype=self._col.dtype,
                 device=self._col.device,
+                partition_book=self._col.partition_book,
                 backend=self.__backend,
             )
-            transposed._col.get_local_tensor().copy_(self._row.get_local_tensor())
-            transposed._row.get_local_tensor().copy_(self._col.get_local_tensor())
+            col_host_view = self._row.device == "cpu"
+            row_host_view = self._col.device == "cpu"
+            transposed._col.get_local_tensor(host_view=col_host_view).copy_(
+                self._row.get_local_tensor(host_view=col_host_view)
+            )
+            transposed._row.get_local_tensor(host_view=row_host_view).copy_(
+                self._col.get_local_tensor(host_view=row_host_view)
+            )
 
         return transposed
 

--- a/python/cugraph-pyg/cugraph_pyg/tensor/dist_tensor.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/dist_tensor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional, Union, Literal
@@ -63,6 +63,7 @@ class DistTensor:
     ):
         self._tensor = None
         self.__device = device
+        self.__partition_book = None if partition_book is None else list(partition_book)
         if src is None:
             # Create an empty WholeGraph tensor
             if shape is None:
@@ -320,6 +321,10 @@ class DistTensor:
     @property
     def device(self):
         return self.__device
+
+    @property
+    def partition_book(self):
+        return None if self.__partition_book is None else list(self.__partition_book)
 
     @property
     def dtype(self):

--- a/python/cugraph-pyg/cugraph_pyg/tensor/utils.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/utils.py
@@ -1,8 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Union, List
 
+import numpy as np
 import os
 
 from cugraph_pyg.utils.imports import import_optional
@@ -48,6 +49,9 @@ def create_wg_dist_tensor(
         The backend for the distributed tensor [ "nccl" | "vmm" | "nvshmem" ]
     """
     global_comm = wgth.get_global_communicator()
+    partition_book = (
+        None if partition_book is None else np.asarray(partition_book, dtype=np.uintp)
+    )
 
     if backend == "nccl":
         embedding_wholememory_type = "distributed"
@@ -126,6 +130,9 @@ def create_wg_dist_tensor_from_files(
         The backend for the distributed tensor [ "nccl" | "vmm" | "nvshmem" ]
     """
     global_comm = wgth.get_global_communicator()
+    partition_book = (
+        None if partition_book is None else np.asarray(partition_book, dtype=np.uintp)
+    )
 
     if backend == "nccl":
         embedding_wholememory_type = "distributed"

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
@@ -43,8 +43,12 @@ def test_feature_store_basic_api(single_pytorch_worker):
 
     assert len(feature_store.get_all_tensor_attrs()) == 3
 
+    dist_tensor = feature_store["node", "feat1", None]
+    feature_store["node", "feat1_alias", None] = dist_tensor
+    assert feature_store["node", "feat1_alias", None] is dist_tensor
+
     del feature_store["node", "feat0", None]
-    assert len(feature_store.get_all_tensor_attrs()) == 2
+    assert len(feature_store.get_all_tensor_attrs()) == 3
 
 
 @pytest.mark.skipif(

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_graph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_graph_store.py
@@ -7,6 +7,7 @@ from cugraph.datasets import karate
 from cugraph_pyg.utils.imports import import_optional, MissingModule
 
 from cugraph_pyg.data import GraphStore
+from cugraph_pyg.tensor import DistMatrix
 
 torch = import_optional("torch")
 
@@ -38,3 +39,32 @@ def test_graph_store_basic_api(single_pytorch_worker, location):
     graph_store.remove_edge_index(("person", "knows", "person"), "coo")
     edge_attrs = graph_store.get_all_edge_attrs()
     assert len(edge_attrs) == 0
+
+    dist_matrix = DistMatrix(src=(dst, src), device=location, format="coo")
+    graph_store.put_edge_index(
+        dist_matrix,
+        ("person", "follows", "person"),
+        "coo",
+        False,
+        (num_nodes, num_nodes),
+    )
+
+    stored_matrix = graph_store._GraphStore__edge_indices[
+        ("person", "follows", "person")
+    ]
+    assert stored_matrix is dist_matrix
+
+    rei = graph_store.get_edge_index(("person", "follows", "person"), "coo")
+    assert (ei == rei).all()
+
+    graph_store.put_edge_index(
+        (dist_matrix._row, dist_matrix._col),
+        ("person", "likes", "person"),
+        "coo",
+        False,
+        (num_nodes, num_nodes),
+    )
+
+    stored_matrix = graph_store._GraphStore__edge_indices[("person", "likes", "person")]
+    assert stored_matrix._row is dist_matrix._row
+    assert stored_matrix._col is dist_matrix._col

--- a/python/cugraph-pyg/cugraph_pyg/tests/tensor/test_dist_matrix_mg.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/tensor/test_dist_matrix_mg.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -46,6 +46,33 @@ def run_test_dist_matrix_creation(rank, world_size, device):
     assert result.shape == (2, 10)
     assert torch.allclose(result[0], col[idx])
     assert torch.allclose(result[1], row[idx])
+
+    torch.distributed.barrier()
+
+    # Test transpose view
+    transposed_view = dist_matrix.transpose(view=True)
+    assert transposed_view._format == "coo"
+    assert transposed_view._col is dist_matrix._row
+    assert transposed_view._row is dist_matrix._col
+    result = transposed_view[idx]
+    assert torch.allclose(result[0], row[idx])
+    assert torch.allclose(result[1], col[idx])
+
+    # Test construction from DistTensor objects retains their references
+    dist_matrix_view = DistMatrix(
+        src=(dist_matrix._col, dist_matrix._row), format="coo"
+    )
+    assert dist_matrix_view._col is dist_matrix._col
+    assert dist_matrix_view._row is dist_matrix._row
+
+    # Test transpose copy
+    transposed = dist_matrix.transpose()
+    assert transposed._format == "coo"
+    assert transposed._col is not dist_matrix._row
+    assert transposed._row is not dist_matrix._col
+    result = transposed[idx]
+    assert torch.allclose(result[0], row[idx])
+    assert torch.allclose(result[1], col[idx])
 
     torch.distributed.barrier()
 
@@ -134,6 +161,30 @@ def run_test_dist_matrix_invalid_cases(rank, world_size, device):
     row = torch.randint(0, 100, (200,), dtype=torch.long, device="cuda")
     with pytest.raises(ValueError):
         DistMatrix(src=(col, row), format="coo", device=device)
+
+    # Test that a CSC transpose view is a CSR sharing the same storage
+    col = torch.randint(0, 100, (100,), dtype=torch.long, device="cuda")
+    row = torch.randint(0, 100, (100,), dtype=torch.long, device="cuda")
+    dist_matrix = DistMatrix(src=(col, row), format="csc", device=device)
+    transposed_view = dist_matrix.transpose(view=True)
+    assert transposed_view._format == "csr"
+    assert transposed_view._col is dist_matrix._row
+    assert transposed_view._row is dist_matrix._col
+
+    # Transposing the CSR view produces a CSC view of the original storage
+    round_trip_view = transposed_view.transpose(view=True)
+    assert round_trip_view._format == "csc"
+    assert round_trip_view._col is dist_matrix._col
+    assert round_trip_view._row is dist_matrix._row
+
+    # Test that copying a transpose converts CSC to CSR and CSR to CSC
+    transposed = dist_matrix.transpose()
+    assert transposed._format == "csr"
+    assert transposed._col is not dist_matrix._row
+    assert transposed._row is not dist_matrix._col
+
+    transposed = transposed.transpose()
+    assert transposed._format == "csc"
 
     wm_finalize()
     torch.distributed.destroy_process_group()

--- a/python/cugraph-pyg/cugraph_pyg/tests/tensor/test_dist_matrix_mg.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/tensor/test_dist_matrix_mg.py
@@ -4,7 +4,7 @@
 
 import os
 import pytest
-from cugraph_pyg.tensor import DistMatrix
+from cugraph_pyg.tensor import DistMatrix, DistTensor
 
 from pylibwholegraph.torch.initialize import init as wm_init
 from pylibwholegraph.binding.wholememory_binding import finalize as wm_finalize
@@ -73,6 +73,41 @@ def run_test_dist_matrix_creation(rank, world_size, device):
     result = transposed[idx]
     assert torch.allclose(result[0], row[idx])
     assert torch.allclose(result[1], col[idx])
+
+    # A transpose copy preserves non-uniform partitions and uses a local view
+    # matching the storage location.
+    partition_book = list(range(1, world_size + 1))
+    partitioned_size = sum(partition_book)
+    partitioned_col = torch.arange(partitioned_size, dtype=torch.long, device="cuda")
+    partitioned_row = partitioned_col.flip(0)
+    partitioned_matrix = DistMatrix(
+        src=(
+            DistTensor(
+                src=partitioned_col,
+                device=device,
+                partition_book=partition_book,
+            ),
+            DistTensor(
+                src=partitioned_row,
+                device=device,
+                partition_book=partition_book,
+            ),
+        ),
+        format="coo",
+    )
+    partitioned_transpose = partitioned_matrix.transpose()
+    assert partitioned_transpose._col.partition_book == partition_book
+    assert partitioned_transpose._row.partition_book == partition_book
+    local_col = partitioned_transpose._col.get_local_tensor(host_view=device == "cpu")
+    local_row = partitioned_transpose._row.get_local_tensor(host_view=device == "cpu")
+    assert local_col.device.type == device
+    assert local_row.device.type == device
+    local_start = sum(partition_book[:rank])
+    local_end = local_start + partition_book[rank]
+    expected_col = partitioned_row[local_start:local_end].to(device)
+    expected_row = partitioned_col[local_start:local_end].to(device)
+    assert torch.equal(local_col, expected_col)
+    assert torch.equal(local_row, expected_row)
 
     torch.distributed.barrier()
 


### PR DESCRIPTION
## Overview

Add transpose support for distributed matrices and allow cuGraph-PyG stores to retain existing distributed objects by reference. This enables callers to build transposed graph views without copying distributed edge data, while still supporting an explicit copy when independent storage is needed.

## Changes

- add `DistMatrix.transpose(view=False)` with both copy and zero-copy view semantics
- swap CSR and CSC formats during transpose while preserving COO format
- allow `DistMatrix` construction from two existing `DistTensor` objects without copying their storage
- allow `FeatureStore` to store a complete `DistTensor` by reference and reject indexed insertion for that path
- allow `GraphStore` to store COO `DistMatrix` instances and `DistTensor` pairs by reference
- document the reference-sharing behavior in the feature and graph store APIs
- update NVIDIA copyright headers in the touched files

## Test coverage

- cover copied and view-based COO transposes
- cover CSC-to-CSR transpose and round-trip CSR-to-CSC behavior
- verify `DistMatrix`, `DistTensor`, `FeatureStore`, and `GraphStore` retain the expected object references

## Validation

The branch includes focused unit and multi-GPU test coverage for the new behavior.
