### PR TITLE
Update PyG support to 2.8

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -36,7 +36,7 @@ dependencies:
 - pytest-cov
 - pytest-forked
 - pytest-xdist
-- pytorch_geometric>=2.5,<2.8
+- pytorch_geometric>=2.5,<2.9
 - rapids-build-backend>=0.4.0,<0.5.0
 - rmm==26.10.*,>=0.0.0a0
 - scikit-build-core>=0.11.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -36,7 +36,7 @@ dependencies:
 - pytest-cov
 - pytest-forked
 - pytest-xdist
-- pytorch_geometric>=2.5,<2.8
+- pytorch_geometric>=2.5,<2.9
 - rapids-build-backend>=0.4.0,<0.5.0
 - rmm==26.10.*,>=0.0.0a0
 - scikit-build-core>=0.11.0

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -36,7 +36,7 @@ dependencies:
 - pytest-cov
 - pytest-forked
 - pytest-xdist
-- pytorch_geometric>=2.5,<2.8
+- pytorch_geometric>=2.5,<2.9
 - rapids-build-backend>=0.4.0,<0.5.0
 - rmm==26.10.*,>=0.0.0a0
 - scikit-build-core>=0.11.0

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -36,7 +36,7 @@ dependencies:
 - pytest-cov
 - pytest-forked
 - pytest-xdist
-- pytorch_geometric>=2.5,<2.8
+- pytorch_geometric>=2.5,<2.9
 - rapids-build-backend>=0.4.0,<0.5.0
 - rmm==26.10.*,>=0.0.0a0
 - scikit-build-core>=0.11.0

--- a/conda/recipes/cugraph-pyg/recipe.yaml
+++ b/conda/recipes/cugraph-pyg/recipe.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 schema_version: 1
 

--- a/conda/recipes/cugraph-pyg/recipe.yaml
+++ b/conda/recipes/cugraph-pyg/recipe.yaml
@@ -40,7 +40,7 @@ requirements:
     # because we want it to be possible to at least install `cugraph-pyg` in an environment without a GPU,
     # to support use cases like building container images.
     - pytorch >=2.3
-    - pytorch_geometric >=2.5,<2.8
+    - pytorch_geometric >=2.5,<2.9
 
 tests:
   - python:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -551,7 +551,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - pytorch_geometric>=2.5,<2.8
+          - pytorch_geometric>=2.5,<2.9
     specific:
       # no 'pyproject'... we intentionally keep 'torch-geometric' out of wheel
       # metadata so it's possible to install 'cugraph-pyg' without 'torch'
@@ -562,7 +562,7 @@ dependencies:
             packages:
           - matrix:
             packages:
-              - torch-geometric>=2.5,<2.8
+              - torch-geometric>=2.5,<2.9
   depends_on_pylibwholegraph:
     common:
       - output_types: conda

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-aarch64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-aarch64.yaml
@@ -12,6 +12,6 @@ dependencies:
 - pytest-benchmark
 - pytest-cov
 - pytest-xdist
-- pytorch_geometric>=2.5,<2.8
+- pytorch_geometric>=2.5,<2.9
 - torchdata
 name: cugraph_pyg_dev_cuda-129_arch-aarch64

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-x86_64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-x86_64.yaml
@@ -12,6 +12,6 @@ dependencies:
 - pytest-benchmark
 - pytest-cov
 - pytest-xdist
-- pytorch_geometric>=2.5,<2.8
+- pytorch_geometric>=2.5,<2.9
 - torchdata
 name: cugraph_pyg_dev_cuda-129_arch-x86_64

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-aarch64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-aarch64.yaml
@@ -12,6 +12,6 @@ dependencies:
 - pytest-benchmark
 - pytest-cov
 - pytest-xdist
-- pytorch_geometric>=2.5,<2.8
+- pytorch_geometric>=2.5,<2.9
 - torchdata
 name: cugraph_pyg_dev_cuda-133_arch-aarch64

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-x86_64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-x86_64.yaml
@@ -12,6 +12,6 @@ dependencies:
 - pytest-benchmark
 - pytest-cov
 - pytest-xdist
-- pytorch_geometric>=2.5,<2.8
+- pytorch_geometric>=2.5,<2.9
 - torchdata
 name: cugraph_pyg_dev_cuda-133_arch-x86_64


### PR DESCRIPTION
## Summary

- allow PyTorch Geometric 2.8 for pip/requirements dependencies
- allow PyTorch Geometric 2.8 for conda dependencies and generated environments
- preserve the existing minimum supported version of 2.5

## Impact

cuGraph-PyG environments can resolve PyG 2.8 while continuing to support PyG versions starting at 2.5.

## Validation

- `pre-commit run rapids-dependency-file-generator --all-files`
- `git diff --check`
