### PR TITLE
Drop unused Python test dependencies

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -29,7 +29,6 @@ dependencies:
 - numpy>=2.0,<3.0
 - pandas
 - pre-commit
-- pydantic
 - pylibcugraph==26.10.*,>=0.0.0a0
 - pytest
 - pytest-benchmark

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -42,6 +42,5 @@ dependencies:
 - scikit-build-core>=0.11.0
 - scipy
 - setuptools>=77.0.0
-- torchdata
 - wheel
 name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -42,6 +42,5 @@ dependencies:
 - scikit-build-core>=0.11.0
 - scipy
 - setuptools>=77.0.0
-- torchdata
 - wheel
 name: all_cuda-129_arch-x86_64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -29,7 +29,6 @@ dependencies:
 - numpy>=2.0,<3.0
 - pandas
 - pre-commit
-- pydantic
 - pylibcugraph==26.10.*,>=0.0.0a0
 - pytest
 - pytest-benchmark

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -42,6 +42,5 @@ dependencies:
 - scikit-build-core>=0.11.0
 - scipy
 - setuptools>=77.0.0
-- torchdata
 - wheel
 name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -29,7 +29,6 @@ dependencies:
 - numpy>=2.0,<3.0
 - pandas
 - pre-commit
-- pydantic
 - pylibcugraph==26.10.*,>=0.0.0a0
 - pytest
 - pytest-benchmark

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -42,6 +42,5 @@ dependencies:
 - scikit-build-core>=0.11.0
 - scipy
 - setuptools>=77.0.0
-- torchdata
 - wheel
 name: all_cuda-133_arch-x86_64

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -29,7 +29,6 @@ dependencies:
 - numpy>=2.0,<3.0
 - pandas
 - pre-commit
-- pydantic
 - pylibcugraph==26.10.*,>=0.0.0a0
 - pytest
 - pytest-benchmark

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -399,7 +399,6 @@ dependencies:
             packages:
           - matrix:
             packages:
-              - torchdata
               - pydantic
   test_python_pylibwholegraph:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -391,15 +391,6 @@ dependencies:
           - pytest-benchmark
           - pytest-cov
           - pytest-xdist
-    specific:
-      - output_types: [conda]
-        matrices:
-          - matrix:
-              no_pytorch: "true"
-            packages:
-          - matrix:
-            packages:
-              - pydantic
   test_python_pylibwholegraph:
     common:
       - output_types: [conda, pyproject, requirements]

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-aarch64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-aarch64.yaml
@@ -13,5 +13,4 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - pytorch_geometric>=2.5,<2.8
-- torchdata
 name: cugraph_pyg_dev_cuda-129_arch-aarch64

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-aarch64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-aarch64.yaml
@@ -6,7 +6,6 @@ channels:
 - conda-forge
 dependencies:
 - pre-commit
-- pydantic
 - pylibcugraph==26.10.*,>=0.0.0a0
 - pytest
 - pytest-benchmark

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-x86_64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-x86_64.yaml
@@ -13,5 +13,4 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - pytorch_geometric>=2.5,<2.8
-- torchdata
 name: cugraph_pyg_dev_cuda-129_arch-x86_64

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-x86_64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-129_arch-x86_64.yaml
@@ -6,7 +6,6 @@ channels:
 - conda-forge
 dependencies:
 - pre-commit
-- pydantic
 - pylibcugraph==26.10.*,>=0.0.0a0
 - pytest
 - pytest-benchmark

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-aarch64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-aarch64.yaml
@@ -13,5 +13,4 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - pytorch_geometric>=2.5,<2.8
-- torchdata
 name: cugraph_pyg_dev_cuda-133_arch-aarch64

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-aarch64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-aarch64.yaml
@@ -6,7 +6,6 @@ channels:
 - conda-forge
 dependencies:
 - pre-commit
-- pydantic
 - pylibcugraph==26.10.*,>=0.0.0a0
 - pytest
 - pytest-benchmark

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-x86_64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-x86_64.yaml
@@ -13,5 +13,4 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - pytorch_geometric>=2.5,<2.8
-- torchdata
 name: cugraph_pyg_dev_cuda-133_arch-x86_64

--- a/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-x86_64.yaml
+++ b/python/cugraph-pyg/conda/cugraph_pyg_dev_cuda-133_arch-x86_64.yaml
@@ -6,7 +6,6 @@ channels:
 - conda-forge
 dependencies:
 - pre-commit
-- pydantic
 - pylibcugraph==26.10.*,>=0.0.0a0
 - pytest
 - pytest-benchmark


### PR DESCRIPTION
## Summary

- remove unused `torchdata` and `pydantic` entries from the Python test dependency matrix
- regenerate the tracked conda development and all-dependencies environments

## Impact

cuGraph-GNN test environments no longer install the unused `torchdata` and `pydantic` packages.

## Validation

- `pre-commit run rapids-dependency-file-generator --all-files`
- `git diff --check`
- confirmed no remaining `torchdata` or `pydantic` references outside changelog/history
