### PR TITLE
Fix dist matrix local access

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/tensor/dist_matrix.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/dist_matrix.py
@@ -5,6 +5,7 @@ from typing import Optional, Union, Tuple, List, Literal
 
 from cugraph_pyg.utils.imports import import_optional
 from cugraph_pyg.tensor import DistTensor
+from cugraph_pyg.tensor.utils import synchronize_stream_and_barrier
 
 torch = import_optional("torch")
 
@@ -94,7 +95,8 @@ class DistMatrix:
     ):
         if isinstance(idx, slice):
             size = self._col.shape[0]
-            idx = torch.arange(size)[idx]
+            start, stop, step = idx.indices(size)
+            idx = torch.arange(start, stop, step)
 
         if self._format != "coo":
             raise ValueError("Updating is currently only supported for COO format")
@@ -112,6 +114,12 @@ class DistMatrix:
                 raise ValueError("val must be a tuple of two tensors")
             self._col[idx] = val[0]
             self._row[idx] = val[1]
+
+        # WholeMemory scatter runs on the current PyTorch CUDA stream, while
+        # the communicator barrier runs on an internal stream.  Order the
+        # streams before synchronizing ranks so local views cannot observe
+        # an incomplete local or remote update.
+        synchronize_stream_and_barrier(self._col.get_comm())
 
     def __getitem__(self, idx: "torch.Tensor") -> "torch.Tensor":
         if self._format != "coo":
@@ -177,35 +185,11 @@ class DistMatrix:
 
     @property
     def local_col(self) -> "torch.Tensor":
-        world_size = torch.distributed.get_world_size()
-        rank = torch.distributed.get_rank()
-
-        sz = self._col.shape[0]
-
-        q = sz // world_size
-        r = sz % world_size
-
-        if rank < r:
-            ix = torch.arange(q * rank + rank, q * (rank + 1) + rank + 1)
-        else:
-            ix = torch.arange(q * rank + r, q * (rank + 1) + r)
-        return self._col[ix]
+        return self._col.get_local_tensor()
 
     @property
     def local_row(self) -> "torch.Tensor":
-        world_size = torch.distributed.get_world_size()
-        rank = torch.distributed.get_rank()
-
-        sz = self._row.shape[0]
-
-        q = sz // world_size
-        r = sz % world_size
-
-        if rank < r:
-            ix = torch.arange(q * rank + rank, q * (rank + 1) + rank + 1)
-        else:
-            ix = torch.arange(q * rank + r, q * (rank + 1) + r)
-        return self._row[ix]
+        return self._row.get_local_tensor()
 
     @property
     def local_coo(self) -> "torch.Tensor":

--- a/python/cugraph-pyg/cugraph_pyg/tensor/dist_matrix.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/dist_matrix.py
@@ -62,6 +62,10 @@ class DistMatrix:
                         "col and row must have the same number of "
                         "elements for COO format"
                     )
+                if self._col.partition_book != self._row.partition_book:
+                    raise ValueError(
+                        "col and row must have matching partition books for COO format"
+                    )
         elif src is None:
             if dtype is None or shape is None:
                 raise ValueError("dtype and shape must be provided if src is None")

--- a/python/cugraph-pyg/cugraph_pyg/tensor/utils.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/utils.py
@@ -12,11 +12,17 @@ torch = import_optional("torch")
 wgth = import_optional("pylibwholegraph.torch")
 
 
+def synchronize_stream_and_barrier(wm_comm):
+    """Wait for work on the current PyTorch stream, then synchronize ranks."""
+    torch.cuda.current_stream().synchronize()
+    wm_comm.barrier()
+
+
 def copy_host_global_tensor_to_local(wm_tensor, host_tensor, wm_comm):
     local_tensor, local_start = wm_tensor.get_local_tensor(host_view=False)
 
     local_tensor.copy_(host_tensor[local_start : local_start + local_tensor.shape[0]])
-    wm_comm.barrier()
+    synchronize_stream_and_barrier(wm_comm)
 
 
 def create_wg_dist_tensor(

--- a/python/cugraph-pyg/cugraph_pyg/tests/tensor/test_dist_matrix_mg.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/tensor/test_dist_matrix_mg.py
@@ -109,6 +109,14 @@ def run_test_dist_matrix_creation(rank, world_size, device):
     assert torch.equal(local_col, expected_col)
     assert torch.equal(local_row, expected_row)
 
+    # Matrix accessors use the actual partition and share WholeGraph storage.
+    local_col = partitioned_matrix.local_col
+    local_row = partitioned_matrix.local_row
+    assert local_col.data_ptr() == partitioned_matrix._col.get_local_tensor().data_ptr()
+    assert local_row.data_ptr() == partitioned_matrix._row.get_local_tensor().data_ptr()
+    assert torch.equal(local_col.cpu(), partitioned_col[local_start:local_end].cpu())
+    assert torch.equal(local_row.cpu(), partitioned_row[local_start:local_end].cpu())
+
     torch.distributed.barrier()
 
     wm_finalize()
@@ -158,6 +166,21 @@ def run_test_dist_matrix_empty_creation(rank, world_size, device):
     out = dist_matrix[perm]
     assert torch.allclose(out[0], val_col)
     assert torch.allclose(out[1], val_row)
+
+    # Local access is a zero-copy view and observes the completed scatter.
+    local_start = dist_matrix._col.get_local_offset()
+    local_size = dist_matrix._col.get_local_tensor().shape[0]
+    local_end = local_start + local_size
+    expected_col = torch.empty_like(val_col)
+    expected_row = torch.empty_like(val_row)
+    expected_col[perm] = val_col
+    expected_row[perm] = val_row
+    local_col = dist_matrix.local_col
+    local_row = dist_matrix.local_row
+    assert local_col.data_ptr() == dist_matrix._col.get_local_tensor().data_ptr()
+    assert local_row.data_ptr() == dist_matrix._row.get_local_tensor().data_ptr()
+    assert torch.equal(local_col.cpu(), expected_col[local_start:local_end].cpu())
+    assert torch.equal(local_row.cpu(), expected_row[local_start:local_end].cpu())
 
     wm_finalize()
     torch.distributed.destroy_process_group()

--- a/python/cugraph-pyg/cugraph_pyg/tests/tensor/test_dist_matrix_mg.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/tensor/test_dist_matrix_mg.py
@@ -220,6 +220,25 @@ def run_test_dist_matrix_invalid_cases(rank, world_size, device):
     with pytest.raises(ValueError):
         DistMatrix(src=(col, row), format="coo", device=device)
 
+    # COO coordinates must use the same partitioning so local pairs align.
+    if world_size > 1:
+        size = 2 * world_size
+        values = torch.arange(size, dtype=torch.long, device="cuda")
+        col_partition_book = [1] * (world_size - 1) + [world_size + 1]
+        row_partition_book = [2] * world_size
+        col = DistTensor(
+            src=values,
+            device=device,
+            partition_book=col_partition_book,
+        )
+        row = DistTensor(
+            src=values,
+            device=device,
+            partition_book=row_partition_book,
+        )
+        with pytest.raises(ValueError, match="matching partition books"):
+            DistMatrix(src=(col, row), format="coo")
+
     # Test that a CSC transpose view is a CSR sharing the same storage
     col = torch.randint(0, 100, (100,), dtype=torch.long, device="cuda")
     row = torch.randint(0, 100, (100,), dtype=torch.long, device="cuda")


### PR DESCRIPTION
## Description

Fixes a race where `DistMatrix` local accessors could return stale or uninitialized data immediately after WholeGraph tensor initialization or updates.

WholeGraph scatter and copy operations run on the current PyTorch CUDA stream, while the WholeGraph communicator barrier uses an internal stream. A barrier alone therefore does not guarantee that preceding PyTorch stream work has completed.

This change explicitly synchronizes the current PyTorch CUDA stream before entering the communicator barrier.

## Changes

- Synchronize the current PyTorch CUDA stream before WholeGraph communicator barriers during:
  - distributed tensor initialization
  - `DistMatrix` updates
- Restore zero-copy `local_col` and `local_row` access using `get_local_tensor()`.
- Remove the distributed gathers previously used to work around the synchronization race.
- Avoid constructing a full-size index tensor for partial slice assignments.
- Add multi-GPU tests covering:
  - visibility of updates through local accessors
  - zero-copy storage sharing
  - non-uniform WholeGraph partitions

## Memory impact

The zero-copy local accessors avoid temporary allocations previously required for:

- CPU index tensors
- copied CUDA index tensors
- CUDA gather outputs

Partial slice assignments also allocate indices only for the selected range instead of first constructing an index tensor for the entire matrix.

## Performance considerations

Updates now include a CUDA stream synchronization and communicator barrier to guarantee visibility across ranks. This adds synchronization overhead to updates, but removes the gather and allocation overhead from every local accessor call.

## Testing

```text
python -m pytest python/cugraph-pyg/cugraph_pyg/tests/tensor -q

19 passed