### PR TITLE
Make `use_cuda_wheels` and `cuda_suffixed` explicit

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -85,7 +85,7 @@ PYTHON_ARGS_FOR_INSTALL=(
     --no-build-isolation
     --no-deps
     --config-settings="rapidsai.disable-cuda=true"
-    --config-settings="rapidsai.matrix-entry=cuda=${RAPIDS_CUDA_VERSION};use_cuda_wheels=false"
+    --config-settings="rapidsai.matrix-entry=cuda=${RAPIDS_CUDA_VERSION};cuda_suffixed=false;use_cuda_wheels=false"
 )
 
 # Set defaults for vars that may not have been defined externally

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # cugraph build script
@@ -85,6 +85,7 @@ PYTHON_ARGS_FOR_INSTALL=(
     --no-build-isolation
     --no-deps
     --config-settings="rapidsai.disable-cuda=true"
+    --config-settings="rapidsai.matrix-entry=cuda=${RAPIDS_CUDA_VERSION};use_cuda_wheels=false"
 )
 
 # Set defaults for vars that may not have been defined externally

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -78,6 +78,9 @@ files:
       - test_python_pylibwholegraph
   py_build_libwholegraph:
     output: pyproject
+    matrix:
+      use_cuda_wheels: ["true"]
+      cuda_suffixed: ["false"]
     pyproject_dir: python/libwholegraph
     extras:
       table: build-system
@@ -85,6 +88,9 @@ files:
       - rapids_build_skbuild
   py_rapids_build_libwholegraph:
     output: pyproject
+    matrix:
+      use_cuda_wheels: ["true"]
+      cuda_suffixed: ["false"]
     pyproject_dir: python/libwholegraph
     extras:
       table: tool.rapids-build-backend
@@ -95,6 +101,9 @@ files:
       - depends_on_librmm
   py_run_libwholegraph:
     output: pyproject
+    matrix:
+      use_cuda_wheels: ["true"]
+      cuda_suffixed: ["false"]
     pyproject_dir: python/libwholegraph
     extras:
       table: project
@@ -103,6 +112,9 @@ files:
       - depends_on_nccl
   py_build_pylibwholegraph:
     output: pyproject
+    matrix:
+      use_cuda_wheels: ["true"]
+      cuda_suffixed: ["false"]
     pyproject_dir: python/pylibwholegraph
     extras:
       table: build-system
@@ -110,6 +122,9 @@ files:
       - rapids_build_skbuild
   py_rapids_build_pylibwholegraph:
     output: pyproject
+    matrix:
+      use_cuda_wheels: ["true"]
+      cuda_suffixed: ["false"]
     pyproject_dir: python/pylibwholegraph
     extras:
       table: tool.rapids-build-backend
@@ -122,6 +137,9 @@ files:
       - depends_on_librmm
   py_run_pylibwholegraph:
     output: pyproject
+    matrix:
+      use_cuda_wheels: ["true"]
+      cuda_suffixed: ["false"]
     pyproject_dir: python/pylibwholegraph
     extras:
       table: project
@@ -130,6 +148,9 @@ files:
       - depends_on_libwholegraph
   py_test_pylibwholegraph:
     output: pyproject
+    matrix:
+      use_cuda_wheels: ["true"]
+      cuda_suffixed: ["false"]
     pyproject_dir: python/pylibwholegraph
     extras:
       table: project.optional-dependencies
@@ -139,6 +160,9 @@ files:
       - test_python_pylibwholegraph
   py_build_cugraph_pyg:
     output: pyproject
+    matrix:
+      use_cuda_wheels: ["true"]
+      cuda_suffixed: ["false"]
     pyproject_dir: python/cugraph-pyg
     extras:
       table: build-system
@@ -146,6 +170,9 @@ files:
       - rapids_build_setuptools
   py_run_cugraph_pyg:
     output: pyproject
+    matrix:
+      use_cuda_wheels: ["true"]
+      cuda_suffixed: ["false"]
     pyproject_dir: python/cugraph-pyg
     extras:
       table: project
@@ -156,6 +183,9 @@ files:
       - python_run_cugraph_pyg
   py_test_cugraph_pyg:
     output: pyproject
+    matrix:
+      use_cuda_wheels: ["true"]
+      cuda_suffixed: ["false"]
     pyproject_dir: python/cugraph-pyg
     extras:
       table: project.optional-dependencies
@@ -800,10 +830,12 @@ dependencies:
               - *cupy_cu13
           - matrix:
               cuda: "12.*"
+              use_cuda_wheels: "true"
             packages:
               - cupy-cuda12x[ctk]>=14.0.1,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
+              use_cuda_wheels: "true"
             packages:
               - cupy-cuda13x[ctk]>=14.0.1,!=14.1.0
   depends_on_cugraph_pyg:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -606,7 +606,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - pylibwholegraph-cu13==26.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*pylibwholegraph_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*pylibwholegraph_unsuffixed]
   depends_on_libraft:
     common:
       - output_types: conda
@@ -629,7 +631,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - libraft-cu13==26.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*libraft_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*libraft_unsuffixed]
   depends_on_librmm:
     common:
       - output_types: conda
@@ -652,7 +656,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - librmm-cu13==26.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*librmm_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*librmm_unsuffixed]
   depends_on_libwholegraph:
     common:
       - output_types: conda
@@ -675,7 +681,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - libwholegraph-cu13==26.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*libwholegraph_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*libwholegraph_unsuffixed]
   depends_on_libwholegraph_tests:
     common:
       - output_types: conda
@@ -703,7 +711,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - rmm-cu13==26.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*rmm_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*rmm_unsuffixed]
   depends_on_pylibcugraph:
     common:
       - output_types: conda
@@ -726,7 +736,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - pylibcugraph-cu13==26.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*pylibcugraph_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*pylibcugraph_unsuffixed]
   depends_on_cugraph:
     common:
       - output_types: conda
@@ -750,7 +762,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - cugraph-cu13==26.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*cugraph_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*cugraph_unsuffixed]
   depends_on_cuml:
     common:
       - output_types: conda
@@ -773,7 +787,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - cuml-cu13==26.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*cuml_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*cuml_unsuffixed]
   depends_on_cudf:
     common:
       - output_types: conda
@@ -796,7 +812,9 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - cudf-cu13==26.10.*,>=0.0.0a0
-          - {matrix: null, packages: [*cudf_unsuffixed]}
+          - matrix:
+              cuda_suffixed: "false"
+            packages: [*cudf_unsuffixed]
   depends_on_cupy:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -550,6 +550,7 @@ dependencies:
             packages:
               - nvidia-nccl-cu13>=2.19
           - matrix:
+              cuda_suffixed: "false"
             packages:
   depends_on_ogb:
     common:

--- a/python/cugraph-pyg/pyproject.toml
+++ b/python/cugraph-pyg/pyproject.toml
@@ -81,7 +81,7 @@ include = [
 [tool.rapids-build-backend]
 build-backend = "setuptools.build_meta"
 dependencies-file = "../../dependencies.yaml"
-matrix-entry = "cuda_suffixed=true"
+matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 
 [tool.pydistcheck]
 select = [

--- a/python/libwholegraph/pyproject.toml
+++ b/python/libwholegraph/pyproject.toml
@@ -62,7 +62,7 @@ regex = "(?P<value>.*)"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
-matrix-entry = "cuda_suffixed=true"
+matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=4.0",
     "libraft==26.10.*,>=0.0.0a0",

--- a/python/pylibwholegraph/pyproject.toml
+++ b/python/pylibwholegraph/pyproject.toml
@@ -47,7 +47,7 @@ test = [
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
-matrix-entry = "cuda_suffixed=true"
+matrix-entry = "cuda_suffixed=true;use_cuda_wheels=true"
 requires = [
     "cmake>=4.0",
     "cython>=3.2.2",


### PR DESCRIPTION
In order to support https://github.com/rapidsai/issues/132, matrix parameters like `use_cuda_wheels` and `cuda_suffixed` have to be explicit so that the `verify-dependencies` hook doesn't produce false positives. Make them explicit so we can use the hook.