### PR TITLE
Update Temporal Sampling API Calls, Fix Tests, Disable Negative+Temporal Sampling Tests

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
+++ b/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
@@ -780,6 +780,9 @@ class DistributedNeighborSampler(BaseDistributedSampler):
         vertex_type_offsets: Optional[TensorType] = None,
         num_edge_types: int = 1,
     ):
+        # pylibcugraph requires temporal sampling to be disjoint.
+        disjoint = disjoint or temporal
+
         self.__fanout = fanout
         self.__func_kwargs = {
             "h_fan_out": np.asarray(fanout, dtype="int32"),
@@ -808,6 +811,7 @@ class DistributedNeighborSampler(BaseDistributedSampler):
         if temporal:
             self.__func_kwargs["temporal_property_name"] = "time"
             self.__func_kwargs["temporal_sampling_comparison"] = temporal_comparison
+            self.__func_kwargs["starting_vertex_start_times"] = None
 
         if heterogeneous:
             if vertex_type_offsets is None:
@@ -897,7 +901,7 @@ class DistributedNeighborSampler(BaseDistributedSampler):
         }
         kwargs.update(self.__func_kwargs)
         if seed_times is not None:
-            kwargs.update({"starting_vertex_times": cupy.asarray(seed_times)})
+            kwargs.update({"starting_vertex_start_times": cupy.asarray(seed_times)})
 
         sampling_results_dict = self.__func(**kwargs)
 

--- a/python/cugraph-pyg/cugraph_pyg/tests/loader/test_neighbor_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/loader/test_neighbor_loader.py
@@ -1051,8 +1051,8 @@ def test_neighbor_loader_temporal_hetero(single_pytorch_worker, biased):
     assert sorted(out["author"].n_id.tolist()) == [0, 1, 2]
     assert out["paper"].n_id.tolist() == [3, 2, 1, 0]
 
-    assert sorted(out["author", "writes", "paper"].e_id.tolist()) == [0, 2, 4, 5]
-    assert out["author", "writes", "paper"].num_sampled_edges.tolist() == [2, 2, 0]
+    assert sorted(out["author", "writes", "paper"].e_id.tolist()) == [0, 2, 4]
+    assert out["author", "writes", "paper"].num_sampled_edges.tolist() == [2, 1, 0]
 
 
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
@@ -1166,13 +1166,16 @@ def test_neighbor_loader_temporal_linkpred_heterogeneous(single_pytorch_worker, 
     assert sorted(out["author"].n_id.tolist()) == [0, 1, 2]
     assert out["paper"].n_id.tolist() == [3, 2, 1, 0]
 
-    assert sorted(out["author", "writes", "paper"].e_id.tolist()) == [0, 2, 4, 5]
-    assert out["author", "writes", "paper"].num_sampled_edges.tolist() == [2, 2, 0]
+    assert sorted(out["author", "writes", "paper"].e_id.tolist()) == [2, 4]
+    assert out["author", "writes", "paper"].num_sampled_edges.tolist() == [1, 1, 0]
 
     # FIXME resolve issues with num_sampled_nodes
 
 
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.skip(
+    reason="Temporal negative sampling frequently generates empty batches which result in an error"
+)
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("neg_sampling_mode", ["binary", "triplet"])
 @pytest.mark.sg
@@ -1187,11 +1190,11 @@ def test_link_neighbor_loader_temporal_negative_sampling_homogeneous(
     3. Both positive and negative samples are present in the output
     """
     # Create a homogeneous temporal graph with paper-paper citations
-    src_cite = torch.tensor([3, 2, 1, 2, 3, 4, 0])  # paper
-    dst_cite = torch.tensor([2, 1, 0, 0, 1, 2, 1])  # paper
-    tme_cite = torch.tensor([5, 6, 7, 3, 4, 8, 2])  # edge timestamps
+    src_cite = torch.tensor([3, 2, 1, 2, 3, 4, 0, 3, 0, 5])  # paper
+    dst_cite = torch.tensor([2, 1, 0, 0, 1, 2, 1, 4, 5, 4])  # paper
+    tme_cite = torch.tensor([5, 6, 7, 3, 4, 8, 2, 6, 5, 3])  # edge timestamps
 
-    num_papers = 5
+    num_papers = 6
 
     # Create node timestamps (papers are created/published at specific times)
     node_time = torch.tensor([0, 1, 2, 3, 4])  # paper timestamps
@@ -1211,8 +1214,8 @@ def test_link_neighbor_loader_temporal_negative_sampling_homogeneous(
 
     # Create edge label index for link prediction
     # We'll test prediction for a subset of edges
-    edge_label_index = torch.tensor([[3, 2], [2, 1]])
-    edge_label_time = torch.tensor([10, 10])  # Future time for prediction
+    edge_label_index = torch.tensor([[2, 1], [3, 2]])
+    edge_label_time = torch.tensor([8, 8])  # Future time for prediction
 
     # Configure negative sampling
     if neg_sampling_mode == "binary":
@@ -1285,6 +1288,9 @@ def test_link_neighbor_loader_temporal_negative_sampling_homogeneous(
 
 
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.skip(
+    reason="Temporal negative sampling frequently generates empty batches which result in an error"
+)
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("neg_sampling_mode", ["binary", "triplet"])
 @pytest.mark.sg
@@ -1353,8 +1359,10 @@ def test_link_neighbor_loader_temporal_negative_sampling_heterogeneous(
     loader = cugraph_pyg.loader.LinkNeighborLoader(
         (feature_store, graph_store),
         num_neighbors={
-            ("paper", "cites", "paper"): [2, 2],
-            ("author", "writes", "paper"): [2, 2],
+            # One hop keeps this test focused on temporal negative sampling. A
+            # disjoint temporal walk can legitimately have an empty later frontier.
+            ("paper", "cites", "paper"): [2],
+            ("author", "writes", "paper"): [2],
         },
         batch_size=batch_size,
         edge_label_index=(("author", "writes", "paper"), edge_label_index),

--- a/python/cugraph-pyg/cugraph_pyg/tests/loader/test_neighbor_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/loader/test_neighbor_loader.py
@@ -1197,7 +1197,7 @@ def test_link_neighbor_loader_temporal_negative_sampling_homogeneous(
     num_papers = 6
 
     # Create node timestamps (papers are created/published at specific times)
-    node_time = torch.tensor([0, 1, 2, 3, 4])  # paper timestamps
+    node_time = torch.tensor([0, 1, 2, 3, 4, 5, 6])  # paper timestamps
 
     graph_store = GraphStore()
     feature_store = FeatureStore()


### PR DESCRIPTION
Updates the temporal sampling pylibcugraph calls to account for the recent changes (disjoint only, name change for the start time argument).  Also disables the negative temporal sampling tests because those are highly likely to fail now that we're enforcing disjoint sampling.  We will have to figure out an eventual solution for that.

Does not yet expose time windowed sampling. That will be in a future PR.