### PR TITLE
Warn when FeatureStore stores DistTensor by reference

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
@@ -196,6 +196,14 @@ class FeatureStore(
                     "An index cannot be specified when storing a DistTensor "
                     "by reference"
                 )
+            warnings.warn(
+                "Putting a DistTensor into a FeatureStore performs a zero-copy "
+                "operation. The DistTensor is stored by reference and is not moved "
+                "to the FeatureStore's configured storage location, even when the "
+                "FeatureStore and DistTensor storage locations differ.",
+                UserWarning,
+                stacklevel=2,
+            )
             self.__features[(attr.group_name, attr.attr_name)] = tensor
             return True
 

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
@@ -44,9 +44,7 @@ def test_feature_store_basic_api(single_pytorch_worker):
     assert len(feature_store.get_all_tensor_attrs()) == 3
 
     dist_tensor = feature_store["node", "feat1", None]
-    warning = (
-        "Putting a DistTensor into a FeatureStore performs a zero-copy operation"
-    )
+    warning = "Putting a DistTensor into a FeatureStore performs a zero-copy operation"
     with pytest.warns(UserWarning, match=warning):
         feature_store["node", "feat1_alias", None] = dist_tensor
     assert feature_store["node", "feat1_alias", None] is dist_tensor

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
@@ -44,7 +44,11 @@ def test_feature_store_basic_api(single_pytorch_worker):
     assert len(feature_store.get_all_tensor_attrs()) == 3
 
     dist_tensor = feature_store["node", "feat1", None]
-    feature_store["node", "feat1_alias", None] = dist_tensor
+    warning = (
+        "Putting a DistTensor into a FeatureStore performs a zero-copy operation"
+    )
+    with pytest.warns(UserWarning, match=warning):
+        feature_store["node", "feat1_alias", None] = dist_tensor
     assert feature_store["node", "feat1_alias", None] is dist_tensor
 
     del feature_store["node", "feat0", None]


### PR DESCRIPTION
## Summary
- warn when putting a `DistTensor` into the cuGraph-PyG `FeatureStore`
- clarify that insertion is zero-copy and does not relocate the tensor when store and tensor storage locations differ
- verify the warning while preserving the existing reference-identity assertion

## Testing
- `python3 -m py_compile python/cugraph-pyg/cugraph_pyg/data/feature_store.py python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py`
- `git diff --check`
- Verified the new test passes