### PR TITLE
[BUG] Avoid unnecessary FeatureStore scatter copies

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
@@ -182,18 +182,22 @@ class FeatureStore(
         if ix.dim() != 1:
             raise ValueError("Index must be 1D")
 
-        if tensor.is_cuda:
-            # WholeMemory scatter can consume CUDA-visible input directly. Calling
-            # contiguous() preserves an already-contiguous allocation while still
-            # materializing layouts that WholeMemory cannot consume.
+        cuda_visible = tensor.is_cuda or tensor.is_pinned()
+        if cuda_visible and tensor.is_contiguous():
+            scatter_tensor = tensor
+        elif tensor.is_cuda:
             scatter_tensor = tensor.contiguous()
         else:
-            # Keep the copy for CPU tensors. In addition to producing the layout
-            # required by WholeMemory, this gives deserialized tensors fresh storage
-            # before it is made CUDA-visible through pinned memory.
-            scatter_tensor = tensor.cpu().clone(
-                memory_format=torch.contiguous_format
-            ).pin_memory()
+            # Allocate the final layout directly instead of cloning into pageable
+            # memory before pinning it. The copy still gives tensors deserialized
+            # with torch.load fresh storage.
+            scatter_tensor = torch.empty_like(
+                tensor,
+                device="cpu",
+                pin_memory=True,
+                memory_format=torch.contiguous_format,
+            )
+            scatter_tensor.copy_(tensor)
 
         tx[ix] = scatter_tensor
         return tx

--- a/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
@@ -182,7 +182,20 @@ class FeatureStore(
         if ix.dim() != 1:
             raise ValueError("Index must be 1D")
 
-        tx[ix] = tensor.cpu().clone(memory_format=torch.contiguous_format).pin_memory()
+        if tensor.is_cuda:
+            # WholeMemory scatter can consume CUDA-visible input directly. Calling
+            # contiguous() preserves an already-contiguous allocation while still
+            # materializing layouts that WholeMemory cannot consume.
+            scatter_tensor = tensor.contiguous()
+        else:
+            # Keep the copy for CPU tensors. In addition to producing the layout
+            # required by WholeMemory, this gives deserialized tensors fresh storage
+            # before it is made CUDA-visible through pinned memory.
+            scatter_tensor = tensor.cpu().clone(
+                memory_format=torch.contiguous_format
+            ).pin_memory()
+
+        tx[ix] = scatter_tensor
         return tx
 
     def _put_tensor(

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
@@ -59,13 +59,16 @@ def test_feature_store_basic_api(single_pytorch_worker):
 )
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
 @pytest.mark.sg
-@pytest.mark.parametrize("source_device", ["cpu", "cuda"])
+@pytest.mark.parametrize("source_device", ["cpu", "pinned_cpu", "cuda"])
 @pytest.mark.parametrize("noncontiguous", [False, True])
 def test_feature_store_scatter_staging(
     single_pytorch_worker, monkeypatch, source_device, noncontiguous
 ):
-    source = torch.arange(40, dtype=torch.float32, device=source_device).reshape(10, 4)
+    device = "cpu" if source_device == "pinned_cpu" else source_device
+    source = torch.arange(40, dtype=torch.float32, device=device).reshape(10, 4)
     source = source[:, ::2] if noncontiguous else source[:, :2].contiguous()
+    if source_device == "pinned_cpu":
+        source = source.pin_memory()
     assert source.is_contiguous() != noncontiguous
 
     captured = {}
@@ -82,11 +85,11 @@ def test_feature_store_scatter_staging(
 
     scatter_tensor = captured["tensor"]
     assert scatter_tensor.is_contiguous()
-    if source_device == "cuda" and not noncontiguous:
+    if source_device in ("cuda", "pinned_cpu") and not noncontiguous:
         assert scatter_tensor.data_ptr() == source.data_ptr()
     else:
         assert scatter_tensor.data_ptr() != source.data_ptr()
-    if source_device == "cpu":
+    if source_device != "cuda":
         assert scatter_tensor.is_pinned()
 
     actual = feature_store["node", "feat", None].get_local_tensor().cpu()

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
@@ -6,6 +6,7 @@ import pytest
 from cugraph_pyg.utils.imports import import_optional, MissingModule
 
 from cugraph_pyg.data import FeatureStore
+from cugraph_pyg.tensor import DistEmbedding
 
 torch = import_optional("torch")
 torch_geometric = import_optional("torch_geometric")
@@ -51,6 +52,45 @@ def test_feature_store_basic_api(single_pytorch_worker):
 
     del feature_store["node", "feat0", None]
     assert len(feature_store.get_all_tensor_attrs()) == 3
+
+
+@pytest.mark.skipif(
+    isinstance(pylibwholegraph, MissingModule), reason="wholegraph not available"
+)
+@pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.sg
+@pytest.mark.parametrize("source_device", ["cpu", "cuda"])
+@pytest.mark.parametrize("noncontiguous", [False, True])
+def test_feature_store_scatter_staging(
+    single_pytorch_worker, monkeypatch, source_device, noncontiguous
+):
+    source = torch.arange(40, dtype=torch.float32, device=source_device).reshape(10, 4)
+    source = source[:, ::2] if noncontiguous else source[:, :2].contiguous()
+    assert source.is_contiguous() != noncontiguous
+
+    captured = {}
+    original_setitem = DistEmbedding.__setitem__
+
+    def capture_scatter_tensor(self, index, value):
+        captured["tensor"] = value
+        return original_setitem(self, index, value)
+
+    monkeypatch.setattr(DistEmbedding, "__setitem__", capture_scatter_tensor)
+
+    feature_store = FeatureStore()
+    feature_store["node", "feat", None] = source
+
+    scatter_tensor = captured["tensor"]
+    assert scatter_tensor.is_contiguous()
+    if source_device == "cuda" and not noncontiguous:
+        assert scatter_tensor.data_ptr() == source.data_ptr()
+    else:
+        assert scatter_tensor.data_ptr() != source.data_ptr()
+    if source_device == "cpu":
+        assert scatter_tensor.is_pinned()
+
+    actual = feature_store["node", "feat", None].get_local_tensor().cpu()
+    assert (actual == source.cpu()).all()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

- pass contiguous CUDA and pinned-CPU feature tensors directly to WholeMemory scatter
- materialize non-contiguous CUDA layouts with `contiguous()`
- copy other CPU tensors directly into their final contiguous pinned allocation
- test pointer identity, contiguity, pinned CPU staging, and scatter correctness for CPU/CUDA inputs

This removes the unconditional CUDA-to-CPU-to-pinned-host round trip and the redundant pageable CPU clone. It also allows tensors backed by external CUDA-visible allocators, including RMM managed memory, to remain on that allocator when already contiguous.

## Background

The CPU clone predates the unified FeatureStore and was retained because CPU tensors deserialized with `torch.load` could expose storage that did not work reliably with WholeMemory unless copied. Pinning an unpinned tensor already creates new storage. The new path allocates the final contiguous pinned tensor and copies into it once, preserving the fresh-storage behavior without holding an intermediate clone. Already-pinned contiguous CPU tensors need no copy.

## Testing

- `git diff --check`
- Python syntax compilation for both modified files
- Added SG WholeMemory integration coverage for contiguous/non-contiguous CPU, pinned-CPU, and CUDA input
- Verified locally on 8xV100