### PR TITLE
Add last temporal neighbor sampling to cuGraph-PyG

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/loader/link_neighbor_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/loader/link_neighbor_loader.py
@@ -131,8 +131,7 @@ class LinkNeighborLoader(LinkLoader):
         temporal_comparison: str (optional, default='monotonically_decreasing')
             The comparison operator for temporal sampling
             ('strictly_increasing', 'monotonically_increasing',
-            'strictly_decreasing', 'monotonically_decreasing', 'last').
-            Note that this should be 'last' for temporal_strategy='last'.
+            'strictly_decreasing', 'monotonically_decreasing').
             See cugraph_pyg.sampler.BaseDistributedSampler.
         **kwargs
             Other keyword arguments passed to the superclass.

--- a/python/cugraph-pyg/cugraph_pyg/loader/neighbor_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/loader/neighbor_loader.py
@@ -15,6 +15,7 @@ from cugraph_pyg.sampler.distributed_sampler import DistributedNeighborSampler
 from cugraph_pyg.utils.imports import import_optional
 
 torch_geometric = import_optional("torch_geometric")
+torch = import_optional("torch")
 
 
 class NeighborLoader(NodeLoader):
@@ -83,7 +84,10 @@ class NeighborLoader(NodeLoader):
             Whether to perform disjoint sampling.
             See torch_geometric.loader.NeighborLoader.
         temporal_strategy: str (optional, default='uniform')
-            Currently only 'uniform' is suppported.
+            The temporal sampling strategy (``'uniform'`` or ``'last'``).
+            ``'last'`` selects the most recent neighbors within each seed's
+            fixed time window and therefore requires ``input_start_time`` and
+            ``input_end_time``.
             See torch_geometric.loader.NeighborLoader.
         time_attr: str (optional, default=None)
             Used for temporal sampling.
@@ -126,10 +130,11 @@ class NeighborLoader(NodeLoader):
         temporal_comparison: str (optional, default='monotonically_decreasing')
             The comparison operator for temporal sampling
             ('strictly_increasing', 'monotonically_increasing',
-            'strictly_decreasing', 'monotonically_decreasing', 'fixed_window',
-            'last'). ``fixed_window`` is selected automatically when
-            ``input_start_time`` and ``input_end_time`` are provided.
-            Note that this should be 'last' for temporal_strategy='last'.
+            'strictly_decreasing', 'monotonically_decreasing'). Fixed-window
+            sampling is selected automatically when ``input_start_time`` and
+            ``input_end_time`` are provided. ``temporal_strategy='last'`` uses
+            ``'monotonically_increasing'`` to match PyG's inclusive, most-recent
+            neighbor selection.
             See cugraph_pyg.sampler.BaseDistributedSampler.
         input_start_time: OptTensor (optional)
             Lower time-window bounds for each input node. Must be passed together
@@ -153,7 +158,33 @@ class NeighborLoader(NodeLoader):
                 raise ValueError(
                     "input_time cannot be combined with input_start_time or input_end_time"
                 )
-            temporal_comparison = "fixed_window"
+        if temporal_strategy not in ("uniform", "last"):
+            raise ValueError(
+                "Invalid temporal strategy "
+                f"'{temporal_strategy}' (expected 'uniform' or 'last')"
+            )
+        if temporal_strategy == "last":
+            if not has_time_window:
+                raise ValueError(
+                    "temporal_strategy='last' requires both input_start_time "
+                    "and input_end_time"
+                )
+            if replace:
+                raise ValueError(
+                    "temporal_strategy='last' does not support replacement"
+                )
+            if weight_attr is not None:
+                raise ValueError(
+                    "temporal_strategy='last' does not support biased sampling"
+                )
+            if temporal_comparison not in (None, "monotonically_increasing"):
+                raise ValueError(
+                    "temporal_strategy='last' requires "
+                    "temporal_comparison='monotonically_increasing'"
+                )
+            temporal_comparison = "monotonically_increasing"
+        elif has_time_window and temporal_comparison is None:
+            temporal_comparison = "monotonically_increasing"
         elif temporal_comparison is None:
             temporal_comparison = "monotonically_decreasing"
 
@@ -165,8 +196,6 @@ class NeighborLoader(NodeLoader):
             )
         if subgraph_type != torch_geometric.sampler.base.SubgraphType.directional:
             raise ValueError("Only directional subgraphs are currently supported")
-        if temporal_strategy != "uniform":
-            warnings.warn("Only the uniform temporal strategy is currently supported")
         if neighbor_sampler is not None:
             raise ValueError("Passing a neighbor sampler is currently unsupported")
         if is_sorted:
@@ -200,6 +229,22 @@ class NeighborLoader(NodeLoader):
 
         if is_temporal:
             graph_store._set_time_attr((feature_store, time_attr))
+
+            if temporal_strategy == "last":
+                if any(
+                    (edge_time := feature_store[edge_attr.edge_type, time_attr, None])
+                    is not None
+                    and edge_time.dtype != torch.bool
+                    and not edge_time.dtype.is_floating_point
+                    and not edge_time.dtype.is_complex
+                    for edge_attr in graph_store.get_all_edge_attrs()
+                ):
+                    warnings.warn(
+                        "temporal_strategy='last' may be inexact when integer "
+                        "edge timestamps exceed 2**53 because cuGraph converts "
+                        "timestamps to double precision for neighbor ranking.",
+                        UserWarning,
+                    )
 
             if input_time is None and not has_time_window:
                 input_type, input_nodes, _ = (
@@ -242,6 +287,8 @@ class NeighborLoader(NodeLoader):
                 heterogeneous=(not graph_store.is_homogeneous),
                 temporal=is_temporal,
                 temporal_comparison=temporal_comparison,
+                temporal_strategy=temporal_strategy,
+                fixed_window=has_time_window,
                 vertex_type_offsets=graph_store._vertex_offset_array,
                 num_edge_types=len(graph_store.get_all_edge_attrs()),
             ),

--- a/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
+++ b/python/cugraph-pyg/cugraph_pyg/sampler/distributed_sampler.py
@@ -806,6 +806,10 @@ class DistributedNeighborSampler(BaseDistributedSampler):
         Whether to apply temporal constraints during sampling.
     temporal_comparison : str, optional
         Temporal comparison mode passed to pylibcugraph.
+    temporal_strategy : str, optional
+        Temporal neighbor selection strategy (``"uniform"`` or ``"last"``).
+    fixed_window : bool, optional
+        Whether to retain each seed's original time window at every hop.
     vertex_type_offsets : TensorType, optional
         Offsets separating vertex types. Required for heterogeneous sampling.
     num_edge_types : int, optional
@@ -837,13 +841,39 @@ class DistributedNeighborSampler(BaseDistributedSampler):
         heterogeneous: bool = False,
         temporal: bool = False,
         temporal_comparison: Optional[str] = None,
+        temporal_strategy: str = "uniform",
+        fixed_window: bool = False,
         vertex_type_offsets: Optional[TensorType] = None,
         num_edge_types: int = 1,
     ):
+        if temporal_strategy not in ("uniform", "last"):
+            raise ValueError(
+                "Invalid temporal strategy "
+                f"'{temporal_strategy}' (expected 'uniform' or 'last')"
+            )
+        if temporal_strategy == "last":
+            if not temporal:
+                raise ValueError(
+                    "The 'last' temporal strategy requires temporal sampling"
+                )
+            if not fixed_window:
+                raise ValueError(
+                    "The 'last' temporal strategy requires fixed-window sampling"
+                )
+            if with_replacement:
+                raise ValueError(
+                    "The 'last' temporal strategy does not support replacement"
+                )
+            if biased:
+                raise ValueError(
+                    "The 'last' temporal strategy does not support biased sampling"
+                )
+
         # pylibcugraph requires temporal sampling to be disjoint.
         disjoint = disjoint or temporal
 
         self.__fanout = fanout
+        self.__fixed_window = fixed_window
         self.__temporal_comparison = (
             temporal_comparison or "monotonically_decreasing" if temporal else None
         )
@@ -859,6 +889,8 @@ class DistributedNeighborSampler(BaseDistributedSampler):
             "num_edge_types": num_edge_types,
             "use_edge_weights_as_biases": biased,
             "temporal_sampling_comparison": self.__temporal_comparison,
+            "neighbor_selection": "last" if temporal_strategy == "last" else "random",
+            "fixed_window": fixed_window,
         }
 
         if heterogeneous:
@@ -962,7 +994,7 @@ class DistributedNeighborSampler(BaseDistributedSampler):
             )
 
         if seed_times is not None:
-            if self.__temporal_comparison == "fixed_window":
+            if self.__fixed_window:
                 raise ValueError(
                     "fixed-window sampling requires input_start_time and "
                     "input_end_time instead of input_time"
@@ -975,12 +1007,17 @@ class DistributedNeighborSampler(BaseDistributedSampler):
             )
             kwargs[time_key] = cupy.asarray(seed_times)
         elif seed_start_times is not None:
-            if self.__temporal_comparison != "fixed_window":
+            if not self.__fixed_window:
                 raise ValueError(
                     "input_start_time and input_end_time require fixed-window sampling"
                 )
             kwargs["starting_vertex_start_times"] = cupy.asarray(seed_start_times)
             kwargs["starting_vertex_end_times"] = cupy.asarray(seed_end_times)
+        elif self.__fixed_window:
+            raise ValueError(
+                "fixed-window sampling requires both input_start_time and "
+                "input_end_time"
+            )
 
         sampling_results_dict = pylibcugraph.neighbor_sample(**kwargs)
 

--- a/python/cugraph-pyg/cugraph_pyg/tests/loader/test_neighbor_loader.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/loader/test_neighbor_loader.py
@@ -1026,6 +1026,50 @@ def test_neighbor_loader_temporal_fixed_window(single_pytorch_worker, biased):
 
 
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.sg
+def test_neighbor_loader_temporal_last(single_pytorch_worker):
+    src = torch.tensor([0, 0, 0, 2, 2])
+    dst = torch.tensor([1, 2, 3, 4, 5])
+    edge_time = torch.tensor([1, 3, 2, 2, 4])
+
+    graph_store = GraphStore()
+    feature_store = FeatureStore()
+    graph_store[("paper", "cites", "paper"), "coo", False, (6, 6)] = [
+        dst,
+        src,
+    ]
+    feature_store[("paper", "cites", "paper"), "time", None] = edge_time
+
+    with pytest.raises(ValueError, match="requires both input_start_time"):
+        NeighborLoader(
+            (feature_store, graph_store),
+            num_neighbors=[1, 1],
+            input_nodes=torch.tensor([0]),
+            input_time=torch.tensor([3]),
+            time_attr="time",
+            temporal_strategy="last",
+        )
+
+    with pytest.warns(UserWarning, match=r"exceed 2\*\*53"):
+        loader = NeighborLoader(
+            (feature_store, graph_store),
+            num_neighbors=[1, 1],
+            input_nodes=torch.tensor([0]),
+            input_start_time=torch.tensor([0]),
+            input_end_time=torch.tensor([3]),
+            time_attr="time",
+            temporal_strategy="last",
+            shuffle=False,
+        )
+
+    out = next(iter(loader))
+    assert out.n_id.tolist() == [0, 2, 4]
+    assert out.e_id.tolist() == [1, 3]
+    assert out.num_sampled_nodes.tolist() == [1, 1, 1]
+    assert out.num_sampled_edges.tolist() == [1, 1]
+
+
+@pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
 @pytest.mark.parametrize("biased", [True, False])
 @pytest.mark.sg
 def test_neighbor_loader_temporal_hetero(single_pytorch_worker, biased):


### PR DESCRIPTION
## Summary

- map `temporal_strategy=last` to the unified pylibcugraph `neighbor_selection=last` API
- update the fixed-window integration from #524 for the orthogonal `fixed_window` flag introduced by rapidsai/cugraph#5636
- require both lower and upper seed-time bounds for fixed-window last sampling
- reject replacement and biased sampling combinations that libcugraph does not support
- warn that integer edge timestamps above `2**53` may be ranked inexactly
- add homogeneous multi-hop coverage for selecting the newest eligible edge

## Testing

- `/private/tmp/cugraph-gnn-ruff/bin/ruff format --check` on changed files
- `/private/tmp/cugraph-gnn-ruff/bin/ruff check` on changed files
- `PYTHONPYCACHEPREFIX=/private/tmp/cugraph-pyg-pycache python3 -m compileall -q python/cugraph-pyg/cugraph_pyg`
- GPU integration test added but not run locally because the RAPIDS/PyTorch GPU dependencies are unavailable

Depends on #524 and rapidsai/cugraph#5636.