### PR TITLE
Migrate stream APIs from rmm::cuda_stream_view to cuda::stream_ref

### DIFF
--- a/cpp/docs/DEVELOPER_GUIDE.md
+++ b/cpp/docs/DEVELOPER_GUIDE.md
@@ -173,7 +173,7 @@ Similar to a `rmm::device_vector`, allocates a contiguous set of elements in dev
 key differences:
 - As an optimization, elements are uninitialized and no synchronization occurs at construction.
 This limits the types `T` to trivially copyable types.
-- All operations are stream ordered (i.e., they accept a `cuda_stream_view` specifying the stream
+- All operations are stream ordered (i.e., they accept a `cuda::stream_ref` specifying the stream
 on which the operation is performed).
 
 ## Namespaces


### PR DESCRIPTION
## Summary

Track the coordinated migration of stream APIs and call sites from `rmm::cuda_stream_view` to CCCL's `cuda::stream_ref`. This propagates `cuda::stream_ref` through RMM containers and memory resources, RAFT resource and handle APIs, downstream C++ interfaces, Python/Cython bindings, benchmarks, tests, and documentation.

This updates the cuGraph-GNN developer guide to document `cuda::stream_ref` as the stream type used by stream-ordered operations.

Depends on rapidsai/cugraph#5639.

Tracked in rapidsai/build-planning#318.

## Migrations

- Pass `cuda::stream_ref` through stream pools, resource accessors, conditionals, and downstream APIs without converting to `rmm::cuda_stream_view`
- Use `cuda::stream_ref` constructions for default/legacy/per-thread streams
  - `rmm::cuda_stream_default` ➡️ `cuda::stream_ref{cudaStream_t{cudaStreamDefault}}`
  - `rmm::cuda_stream_legacy` ➡️ `cuda::stream_ref{cudaStreamLegacy}`
  - `rmm::cuda_stream_per_thread` ➡️ `cuda::stream_ref{cudaStreamPerThread}`
- Use `.get()` when calling an API that requires a raw `cudaStream_t`, including CUDA runtime, library, CUB, and legacy API boundaries (previously `rmm::cuda_stream_view` used `value()`)
- Use `.sync()` when synchronizing a `cuda::stream_ref` (previously `rmm::cuda_stream_view` used `synchronize()`)
- Update Cython declarations and call sites to pass stream references directly where supported
