### PR TITLE
Add WholeGraph backend options and safer defaults to PyG stores

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
@@ -44,17 +44,20 @@ class FeatureStore(
     visible to the store. Indexed insertion of a DistTensor is not supported.
     """
 
-    def __init__(self, memory_type=None, location="cpu"):
+    def __init__(self, location="cpu", backend=None):
         """
         Constructs an empty FeatureStore.
 
         Parameters
         ----------
-        memory_type: str (optional, default=None)
-            Has no effect.  Retained for compatibility purposes.
-
         location: str(optional, default='cpu')
             The location ('cpu' or 'cuda') where data is stored.
+
+        backend: str(optional, default=None)
+            The WholeGraph backend ('nccl' or 'vmm') used to store data. When
+            omitted, 'vmm' is selected for single-node and multinode NVLink
+            configurations, and 'nccl' is selected for other multinode
+            configurations.
         """
         super().__init__()
 
@@ -62,16 +65,14 @@ class FeatureStore(
 
         self.__wg_location = location
 
-        if int(os.environ["LOCAL_WORLD_SIZE"]) == torch.distributed.get_world_size():
+        if backend is not None:
+            if backend not in ["nccl", "vmm"]:
+                raise ValueError("backend must be 'nccl' or 'vmm'")
+            self.__backend = backend
+        elif int(os.environ["LOCAL_WORLD_SIZE"]) == torch.distributed.get_world_size():
             self.__backend = "vmm"
         else:
             self.__backend = "vmm" if has_nvlink_network() else "nccl"
-
-        if memory_type is not None:
-            warnings.warn(
-                "The memory_type argument is deprecated. "
-                "Memory type is now automatically inferred."
-            )
 
     def __make_wg_tensor(self, tensor, ix=None):
         world_size = torch.distributed.get_world_size()

--- a/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
@@ -7,7 +7,7 @@ import os
 from typing import Optional, Tuple, List
 
 from cugraph_pyg.tensor import DistEmbedding, DistTensor
-from cugraph_pyg.tensor.utils import has_nvlink_network, is_empty
+from cugraph_pyg.tensor.utils import is_empty
 from cugraph_pyg.utils.imports import import_optional, MissingModule
 
 
@@ -55,9 +55,8 @@ class FeatureStore(
 
         backend: str(optional, default=None)
             The WholeGraph backend ('nccl' or 'vmm') used to store data. When
-            omitted, 'vmm' is selected for single-node and multinode NVLink
-            configurations, and 'nccl' is selected for other multinode
-            configurations.
+            omitted, 'vmm' is selected for single-node configurations and
+            'nccl' is selected for multinode configurations.
         """
         super().__init__()
 
@@ -72,7 +71,7 @@ class FeatureStore(
         elif int(os.environ["LOCAL_WORLD_SIZE"]) == torch.distributed.get_world_size():
             self.__backend = "vmm"
         else:
-            self.__backend = "vmm" if has_nvlink_network() else "nccl"
+            self.__backend = "nccl"
 
     def __make_wg_tensor(self, tensor, ix=None):
         world_size = torch.distributed.get_world_size()

--- a/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
@@ -74,7 +74,7 @@ class GraphStore(
     the store.
     """
 
-    def __init__(self, location="cpu"):
+    def __init__(self, location="cpu", backend=None):
         """
         Constructs a new, empty GraphStore object.  This object
         represents one slice of a graph on particular worker.
@@ -86,6 +86,12 @@ class GraphStore(
             edge indices before the cuGraph graph is constructed. This does
             not affect the final graph location; the cuGraph graph is always
             constructed in GPU device memory when it's needed.
+
+        backend: str(optional, default=None)
+            The WholeGraph backend ('nccl' or 'vmm') used to store edge
+            indices. When omitted, 'vmm' is selected for single-node and
+            multinode NVLink configurations, and 'nccl' is selected for other
+            multinode configurations.
         """
         self.__edge_indices = {}
         self.__sizes = {}
@@ -99,7 +105,11 @@ class GraphStore(
 
         self.__clear_graph()
 
-        if int(os.environ["LOCAL_WORLD_SIZE"]) == torch.distributed.get_world_size():
+        if backend is not None:
+            if backend not in ["nccl", "vmm"]:
+                raise ValueError("backend must be 'nccl' or 'vmm'")
+            self.__backend = backend
+        elif int(os.environ["LOCAL_WORLD_SIZE"]) == torch.distributed.get_world_size():
             self.__backend = "vmm"
         else:
             self.__backend = "vmm" if has_nvlink_network() else "nccl"

--- a/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
@@ -14,7 +14,7 @@ from pylibcugraph.comms import cugraph_comms_get_raft_handle
 
 from cugraph_pyg.utils.imports import import_optional, MissingModule
 from cugraph_pyg.tensor import DistTensor, DistMatrix
-from cugraph_pyg.tensor.utils import has_nvlink_network, is_empty
+from cugraph_pyg.tensor.utils import is_empty
 
 from typing import Union, Optional, List, Dict, Tuple, Callable
 
@@ -89,9 +89,9 @@ class GraphStore(
 
         backend: str(optional, default=None)
             The WholeGraph backend ('nccl' or 'vmm') used to store edge
-            indices. When omitted, 'vmm' is selected for single-node and
-            multinode NVLink configurations, and 'nccl' is selected for other
-            multinode configurations.
+            indices. When omitted, 'vmm' is selected for single-node
+            configurations and 'nccl' is selected for multinode
+            configurations.
         """
         self.__edge_indices = {}
         self.__sizes = {}
@@ -112,7 +112,7 @@ class GraphStore(
         elif int(os.environ["LOCAL_WORLD_SIZE"]) == torch.distributed.get_world_size():
             self.__backend = "vmm"
         else:
-            self.__backend = "vmm" if has_nvlink_network() else "nccl"
+            self.__backend = "nccl"
 
         super().__init__()
 

--- a/python/cugraph-pyg/cugraph_pyg/tensor/utils.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/utils.py
@@ -4,7 +4,6 @@
 from typing import Union, List
 
 import numpy as np
-import os
 
 from cugraph_pyg.utils.imports import import_optional
 
@@ -194,29 +193,6 @@ def create_wg_dist_tensor_from_files(
             fail_on_dtype_mismatch=fail_on_dtype_mismatch,
         )
     return wm_embedding
-
-
-def has_nvlink_network():
-    r"""Check if the current hardware supports cross-node NVLink network."""
-
-    global_comm = wgth.comm.get_global_communicator("nccl")
-    local_size = int(os.environ["LOCAL_WORLD_SIZE"])
-
-    world_size = torch.distributed.get_world_size()
-
-    # Intra-node communication
-    if local_size == world_size:
-        # use WholeGraph to check if the current hardware supports direct p2p
-        return global_comm.support_type_location("continuous", "cuda")
-
-    # Check for multi-node support
-    is_cuda_supported = global_comm.support_type_location("continuous", "cuda")
-    is_cpu_supported = global_comm.support_type_location("continuous", "cpu")
-
-    if is_cuda_supported and is_cpu_supported:
-        return True
-
-    return False
 
 
 def is_empty(a):

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
@@ -63,6 +63,27 @@ def test_feature_store_invalid_backend(single_pytorch_worker):
         FeatureStore(backend="invalid")
 
 
+@pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.sg
+@pytest.mark.parametrize(
+    ("local_world_size", "world_size", "expected_backend"),
+    [(2, 2, "vmm"), (1, 2, "nccl")],
+)
+def test_feature_store_default_backend(
+    single_pytorch_worker,
+    monkeypatch,
+    local_world_size,
+    world_size,
+    expected_backend,
+):
+    monkeypatch.setenv("LOCAL_WORLD_SIZE", str(local_world_size))
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: world_size)
+
+    feature_store = FeatureStore()
+
+    assert feature_store._FeatureStore__backend == expected_backend
+
+
 @pytest.mark.skipif(
     isinstance(pylibwholegraph, MissingModule), reason="wholegraph not available"
 )

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
@@ -15,8 +15,10 @@ pylibwholegraph = import_optional("pylibwholegraph")
 
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
 @pytest.mark.sg
-def test_feature_store_basic_api(single_pytorch_worker):
-    feature_store = FeatureStore()
+@pytest.mark.parametrize("backend", ["nccl", "vmm"])
+def test_feature_store_basic_api(single_pytorch_worker, backend):
+    feature_store = FeatureStore(backend=backend)
+    assert feature_store._FeatureStore__backend == backend
 
     node_features_0 = torch.randint(128, (100, 1000))
     node_features_1 = torch.randint(256, (100, 10))
@@ -52,6 +54,13 @@ def test_feature_store_basic_api(single_pytorch_worker):
 
     del feature_store["node", "feat0", None]
     assert len(feature_store.get_all_tensor_attrs()) == 3
+
+
+@pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.sg
+def test_feature_store_invalid_backend(single_pytorch_worker):
+    with pytest.raises(ValueError, match="backend must be 'nccl' or 'vmm'"):
+        FeatureStore(backend="invalid")
 
 
 @pytest.mark.skipif(

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_graph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_graph_store.py
@@ -83,6 +83,27 @@ def test_graph_store_invalid_backend(single_pytorch_worker):
 
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
 @pytest.mark.sg
+@pytest.mark.parametrize(
+    ("local_world_size", "world_size", "expected_backend"),
+    [(2, 2, "vmm"), (1, 2, "nccl")],
+)
+def test_graph_store_default_backend(
+    single_pytorch_worker,
+    monkeypatch,
+    local_world_size,
+    world_size,
+    expected_backend,
+):
+    monkeypatch.setenv("LOCAL_WORLD_SIZE", str(local_world_size))
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: world_size)
+
+    graph_store = GraphStore()
+
+    assert graph_store._GraphStore__backend == expected_backend
+
+
+@pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.sg
 def test_graph_store_finalize(single_pytorch_worker):
     df = karate.get_edgelist()
     src = torch.as_tensor(df["src"], device="cuda")

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_graph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_graph_store.py
@@ -17,7 +17,8 @@ torch_geometric = import_optional("torch_geometric")
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
 @pytest.mark.sg
 @pytest.mark.parametrize("location", ["cpu", "cuda"])
-def test_graph_store_basic_api(single_pytorch_worker, location):
+@pytest.mark.parametrize("backend", ["nccl", "vmm"])
+def test_graph_store_basic_api(single_pytorch_worker, location, backend):
     df = karate.get_edgelist()
     src = torch.as_tensor(df["src"], device="cuda")
     dst = torch.as_tensor(df["dst"], device="cuda")
@@ -26,7 +27,8 @@ def test_graph_store_basic_api(single_pytorch_worker, location):
 
     num_nodes = karate.number_of_nodes()
 
-    graph_store = GraphStore(location=location)
+    graph_store = GraphStore(location=location, backend=backend)
+    assert graph_store._GraphStore__backend == backend
     graph_store.put_edge_index(
         ei, ("person", "knows", "person"), "coo", False, (num_nodes, num_nodes)
     )
@@ -70,6 +72,13 @@ def test_graph_store_basic_api(single_pytorch_worker, location):
     stored_matrix = graph_store._GraphStore__edge_indices[("person", "likes", "person")]
     assert stored_matrix._row is dist_matrix._row
     assert stored_matrix._col is dist_matrix._col
+
+
+@pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.sg
+def test_graph_store_invalid_backend(single_pytorch_worker):
+    with pytest.raises(ValueError, match="backend must be 'nccl' or 'vmm'"):
+        GraphStore(backend="invalid")
 
 
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")


### PR DESCRIPTION
## Summary

- add an optional backend argument to FeatureStore and GraphStore
- accept nccl to force distributed WholeMemory or vmm to force continuous WholeMemory
- default to vmm for single-node runs and nccl for all multinode runs
- remove the insufficient multinode NVLink capability probe
- retain explicit vmm opt-in for validated multinode configurations
- remove the deprecated, no-op FeatureStore memory_type argument
- test explicit selection, invalid values, and single-node versus multinode defaults

The previous automatic selection could choose the VMM/MNNVL path based on broad topology and capability checks that do not prove CUDA fabric-handle import and mapping will succeed. Defaulting multinode stores to NCCL avoids that unsupported inference while preserving an explicit VMM override.

## Validation

- git diff --check
- Python bytecode compilation of the changed modules and tests

The CUDA-dependent pytest cases were not run locally because this environment does not provide the RAPIDS/CUDA test stack.