### PR TITLE
Default multinode PyG stores to NCCL

### DIFF
--- a/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/feature_store.py
@@ -7,7 +7,7 @@ import os
 from typing import Optional, Tuple, List
 
 from cugraph_pyg.tensor import DistEmbedding, DistTensor
-from cugraph_pyg.tensor.utils import has_nvlink_network, is_empty
+from cugraph_pyg.tensor.utils import is_empty
 from cugraph_pyg.utils.imports import import_optional, MissingModule
 
 
@@ -55,9 +55,8 @@ class FeatureStore(
 
         backend: str(optional, default=None)
             The WholeGraph backend ('nccl' or 'vmm') used to store data. When
-            omitted, 'vmm' is selected for single-node and multinode NVLink
-            configurations, and 'nccl' is selected for other multinode
-            configurations.
+            omitted, 'vmm' is selected for single-node configurations and
+            'nccl' is selected for multinode configurations.
         """
         super().__init__()
 
@@ -72,7 +71,7 @@ class FeatureStore(
         elif int(os.environ["LOCAL_WORLD_SIZE"]) == torch.distributed.get_world_size():
             self.__backend = "vmm"
         else:
-            self.__backend = "vmm" if has_nvlink_network() else "nccl"
+            self.__backend = "nccl"
 
     def __make_wg_tensor(self, tensor, ix=None):
         world_size = torch.distributed.get_world_size()

--- a/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/data/graph_store.py
@@ -14,7 +14,7 @@ from pylibcugraph.comms import cugraph_comms_get_raft_handle
 
 from cugraph_pyg.utils.imports import import_optional, MissingModule
 from cugraph_pyg.tensor import DistTensor, DistMatrix
-from cugraph_pyg.tensor.utils import has_nvlink_network, is_empty
+from cugraph_pyg.tensor.utils import is_empty
 
 from typing import Union, Optional, List, Dict, Tuple, Callable
 
@@ -89,9 +89,9 @@ class GraphStore(
 
         backend: str(optional, default=None)
             The WholeGraph backend ('nccl' or 'vmm') used to store edge
-            indices. When omitted, 'vmm' is selected for single-node and
-            multinode NVLink configurations, and 'nccl' is selected for other
-            multinode configurations.
+            indices. When omitted, 'vmm' is selected for single-node
+            configurations and 'nccl' is selected for multinode
+            configurations.
         """
         self.__edge_indices = {}
         self.__sizes = {}
@@ -112,7 +112,7 @@ class GraphStore(
         elif int(os.environ["LOCAL_WORLD_SIZE"]) == torch.distributed.get_world_size():
             self.__backend = "vmm"
         else:
-            self.__backend = "vmm" if has_nvlink_network() else "nccl"
+            self.__backend = "nccl"
 
         super().__init__()
 

--- a/python/cugraph-pyg/cugraph_pyg/tensor/utils.py
+++ b/python/cugraph-pyg/cugraph_pyg/tensor/utils.py
@@ -4,7 +4,6 @@
 from typing import Union, List
 
 import numpy as np
-import os
 
 from cugraph_pyg.utils.imports import import_optional
 
@@ -194,29 +193,6 @@ def create_wg_dist_tensor_from_files(
             fail_on_dtype_mismatch=fail_on_dtype_mismatch,
         )
     return wm_embedding
-
-
-def has_nvlink_network():
-    r"""Check if the current hardware supports cross-node NVLink network."""
-
-    global_comm = wgth.comm.get_global_communicator("nccl")
-    local_size = int(os.environ["LOCAL_WORLD_SIZE"])
-
-    world_size = torch.distributed.get_world_size()
-
-    # Intra-node communication
-    if local_size == world_size:
-        # use WholeGraph to check if the current hardware supports direct p2p
-        return global_comm.support_type_location("continuous", "cuda")
-
-    # Check for multi-node support
-    is_cuda_supported = global_comm.support_type_location("continuous", "cuda")
-    is_cpu_supported = global_comm.support_type_location("continuous", "cpu")
-
-    if is_cuda_supported and is_cpu_supported:
-        return True
-
-    return False
 
 
 def is_empty(a):

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_feature_store.py
@@ -63,6 +63,27 @@ def test_feature_store_invalid_backend(single_pytorch_worker):
         FeatureStore(backend="invalid")
 
 
+@pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.sg
+@pytest.mark.parametrize(
+    ("local_world_size", "world_size", "expected_backend"),
+    [(2, 2, "vmm"), (1, 2, "nccl")],
+)
+def test_feature_store_default_backend(
+    single_pytorch_worker,
+    monkeypatch,
+    local_world_size,
+    world_size,
+    expected_backend,
+):
+    monkeypatch.setenv("LOCAL_WORLD_SIZE", str(local_world_size))
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: world_size)
+
+    feature_store = FeatureStore()
+
+    assert feature_store._FeatureStore__backend == expected_backend
+
+
 @pytest.mark.skipif(
     isinstance(pylibwholegraph, MissingModule), reason="wholegraph not available"
 )

--- a/python/cugraph-pyg/cugraph_pyg/tests/data/test_graph_store.py
+++ b/python/cugraph-pyg/cugraph_pyg/tests/data/test_graph_store.py
@@ -83,6 +83,27 @@ def test_graph_store_invalid_backend(single_pytorch_worker):
 
 @pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
 @pytest.mark.sg
+@pytest.mark.parametrize(
+    ("local_world_size", "world_size", "expected_backend"),
+    [(2, 2, "vmm"), (1, 2, "nccl")],
+)
+def test_graph_store_default_backend(
+    single_pytorch_worker,
+    monkeypatch,
+    local_world_size,
+    world_size,
+    expected_backend,
+):
+    monkeypatch.setenv("LOCAL_WORLD_SIZE", str(local_world_size))
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: world_size)
+
+    graph_store = GraphStore()
+
+    assert graph_store._GraphStore__backend == expected_backend
+
+
+@pytest.mark.skipif(isinstance(torch, MissingModule), reason="torch not available")
+@pytest.mark.sg
 def test_graph_store_finalize(single_pytorch_worker):
     df = karate.get_edgelist()
     src = torch.as_tensor(df["src"], device="cuda")


### PR DESCRIPTION
## Summary

- default FeatureStore and GraphStore to VMM only for single-node runs
- default both stores to NCCL for all multinode runs
- remove the insufficient NVLink-network capability probe
- retain explicit backend overrides for validated VMM configurations
- add tests covering single-node and multinode automatic selection

This PR is stacked on #531 and should be reviewed after it.

## Validation

- git diff --check
- Python compileall
- CUDA-dependent tests require GPU CI