### PR TITLE
Disable flaky parquet reader memory-scaling test

### DIFF
--- a/python/pylibwholegraph/pylibwholegraph/tests/pylibwholegraph/test_tensor_file_formats_io.py
+++ b/python/pylibwholegraph/pylibwholegraph/tests/pylibwholegraph/test_tensor_file_formats_io.py
@@ -51,17 +51,6 @@ def _current_rss_bytes():
             for line in status_file:
                 if line.startswith("VmRSS:"):
                     return int(line.split()[1]) * 1024
-    return _peak_rss_bytes()
-
-
-def _peak_rss_bytes():
-    # Use the kernel-maintained high-water mark so short-lived decode and
-    # conversion buffers cannot fall between samples from _track_peak_rss.
-    if sys.platform.startswith("linux"):
-        with open("/proc/self/status", encoding="utf-8") as status_file:
-            for line in status_file:
-                if line.startswith("VmHWM:"):
-                    return int(line.split()[1]) * 1024
     peak_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
     return peak_rss if sys.platform == "darwin" else peak_rss * 1024
 
@@ -166,7 +155,6 @@ def _structured_memory_worker(
         finally:
             stop_event.set()
             monitor.join()
-            peak_rss[0] = max(peak_rss[0], _peak_rss_bytes())
         peak_increase = peak_rss[0] - baseline_rss
         assert tuple(wm_tensor.shape) == (row_count, column_count)
         result_queue.put(peak_increase)
@@ -202,7 +190,6 @@ def _structured_reader_memory_worker(
     finally:
         stop_event.set()
         monitor.join()
-        peak_rss[0] = max(peak_rss[0], _peak_rss_bytes())
 
     peak_increase = peak_rss[0] - baseline_rss
     assert rows_read == row_count
@@ -420,6 +407,9 @@ def test_parquet_read_has_bounded_peak_host_memory(tmp_path, memory_location):
     )
 
 
+@pytest.mark.skip(
+    reason="Peak RSS includes nondeterministic process startup allocations in CI"
+)
 def test_parquet_reader_has_bounded_peak_host_memory(tmp_path):
     column_count = 16
     row_size = column_count * torch.tensor([], dtype=torch.float32).element_size()


### PR DESCRIPTION
## Description

Disables `test_parquet_reader_has_bounded_peak_host_memory`, which has repeatedly produced false failures in CI.

The test compares RSS measurements from separate spawned processes. Both attempted measurement strategies proved unreliable:

- Polling `VmRSS` could miss short-lived allocations during the smaller dataset read.
- Using `VmHWM` included nondeterministic process startup and import allocations. In the latest [nightly failure](https://github.com/rapidsai/cugraph-gnn/actions/runs/33733743398/job/100660175002), the measured overhead changed from 53.4 MiB to 544.7 MiB between workers, which does not represent Parquet reader scaling.

This change:

- Marks only the unreliable pure-reader RSS test as skipped.
- Reverts the `VmHWM` measurement changes so they cannot affect the remaining CPU/CUDA memory tests.
- Retains the functional Parquet read tests and bounded-memory tests for reads into WholeMemory.

## Testing

- `ruff check` passed.
- `ruff format --check` passed.
- Python compilation passed.
- `git diff --check` passed.
- Full local pytest execution was unavailable because the current local environment does not include PyArrow; CI will provide complete test coverage.