### PR TITLE
Discover CMake packages installed by wheels

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -13,7 +13,6 @@ include(rapids-cpm)
 include(rapids-cuda)
 include(rapids-export)
 include(rapids-find)
-include(${rapids-cmake-dir}/cython-core/find_prefix_paths.cmake)
 
 rapids_cuda_init_architectures(WHOLEGRAPH)
 
@@ -26,6 +25,7 @@ project(
 # Find CMake packages provided by installed wheels.
 find_package(Python COMPONENTS Interpreter)
 if(Python_FOUND)
+  include(${rapids-cmake-dir}/cython-core/find_prefix_paths.cmake)
   rapids_cython_find_prefix_paths("${Python_EXECUTABLE}" wheel_prefix_paths)
   set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
   list(PREPEND CMAKE_PREFIX_PATH ${wheel_prefix_paths})

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ include(rapids-cpm)
 include(rapids-cuda)
 include(rapids-export)
 include(rapids-find)
+include(${rapids-cmake-dir}/cython-core/find_prefix_paths.cmake)
 
 rapids_cuda_init_architectures(WHOLEGRAPH)
 
@@ -21,6 +22,14 @@ project(
   VERSION "${RAPIDS_VERSION}"
   LANGUAGES CXX CUDA
 )
+
+# Find CMake packages provided by installed wheels.
+find_package(Python COMPONENTS Interpreter)
+if(Python_FOUND)
+  rapids_cython_find_prefix_paths("${Python_EXECUTABLE}" wheel_prefix_paths)
+  set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
+  list(PREPEND CMAKE_PREFIX_PATH ${wheel_prefix_paths})
+endif()
 
 # Write the version header
 rapids_cmake_write_version_file(include/wholegraph/version_config.hpp)

--- a/cpp/cmake/thirdparty/get_rmm.cmake
+++ b/cpp/cmake/thirdparty/get_rmm.cmake
@@ -6,10 +6,34 @@
 # =============================================================================
 
 # This function finds RMM and sets any additional necessary environment variables.
-function(find_and_configure_rmm)
+function(find_and_configure_rmm BUILD_SHARED EXCLUDE_FROM_ALL)
   include(${rapids-cmake-dir}/cpm/rmm.cmake)
 
-  rapids_cpm_rmm(BUILD_EXPORT_SET wholegraph-exports INSTALL_EXPORT_SET wholegraph-exports)
+  if(EXCLUDE_FROM_ALL)
+    set(_exclude_flag EXCLUDE_FROM_ALL)
+  else()
+    set(_exclude_flag)
+  endif()
+
+  # Find or install RMM.
+  set(_rmm_args)
+  if(NOT EXCLUDE_FROM_ALL)
+    list(APPEND _rmm_args BUILD_EXPORT_SET wholegraph-exports INSTALL_EXPORT_SET wholegraph-exports)
+  endif()
+  rapids_cpm_rmm(${_rmm_args} ${_exclude_flag} CPM_ARGS OPTIONS "BUILD_SHARED_LIBS ${BUILD_SHARED}")
+
+  # If RMM was found as a pre-existing shared library (e.g. conda), we need find_dependency(rmm) in
+  # the build and installed configs even when EXCLUDE_FROM_ALL is set. EXCLUDE_FROM_ALL controls
+  # whether CPM-built targets are installed, but a pre-existing shared library is not absorbed into
+  # libwholegraph and must be findable by downstream consumers.
+  if(EXCLUDE_FROM_ALL)
+    get_target_property(_rmm_type rmm::rmm TYPE)
+    if(NOT _rmm_type STREQUAL "STATIC_LIBRARY")
+      include("${rapids-cmake-dir}/export/package.cmake")
+      rapids_export_package(BUILD rmm wholegraph-exports VERSION ${rmm_VERSION})
+      rapids_export_package(INSTALL rmm wholegraph-exports VERSION ${rmm_VERSION})
+    endif()
+  endif()
 
   # Propagate RMM source/binary dirs to parent scope.
   set(rmm_SOURCE_DIR
@@ -22,4 +46,4 @@ function(find_and_configure_rmm)
   )
 endfunction()
 
-find_and_configure_rmm()
+find_and_configure_rmm(${BUILD_SHARED_LIBS} TRUE)

--- a/python/pylibwholegraph/CMakeLists.txt
+++ b/python/pylibwholegraph/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/python/pylibwholegraph/CMakeLists.txt
+++ b/python/pylibwholegraph/CMakeLists.txt
@@ -20,6 +20,15 @@ project(
   LANGUAGES CXX CUDA
 )
 
+# Find CMake packages provided by installed wheels.
+find_package(Python COMPONENTS Interpreter)
+if(Python_FOUND)
+  include(${rapids-cmake-dir}/cython-core/find_prefix_paths.cmake)
+  rapids_cython_find_prefix_paths("${Python_EXECUTABLE}" wheel_prefix_paths)
+  set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
+  list(PREPEND CMAKE_PREFIX_PATH ${wheel_prefix_paths})
+endif()
+
 find_package(wholegraph "${RAPIDS_VERSION}" REQUIRED)
 
 include(rapids-cython-core)


### PR DESCRIPTION
Adds `rapids_cython_find_prefix_paths()` so direct CMake builds in pip environments can discover packages provided by installed wheels.

Part of rapidsai/build-planning#325.