### PR TITLE
wheels: test against PyTorch 2.14

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,6 +26,7 @@ jobs:
       - wheel-tests-pylibwholegraph
       - wheel-build-cugraph-pyg
       - wheel-tests-cugraph-pyg
+      - wheel-tests-cugraph-pyg-nightly
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@release/26.10
     if: always()
     with:
@@ -372,6 +373,21 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
+      script: ci/test_wheel_cugraph-pyg.sh
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+  wheel-tests-cugraph-pyg-nightly:
+    needs: [wheel-build-pylibwholegraph, wheel-build-cugraph-pyg, changed-files]
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.10
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
+    with:
+      build_type: pull-request
+      matrix_type: nightly
       script: ci/test_wheel_cugraph-pyg.sh
     permissions:
       actions: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,6 @@ jobs:
       - wheel-tests-pylibwholegraph
       - wheel-build-cugraph-pyg
       - wheel-tests-cugraph-pyg
-      - wheel-tests-cugraph-pyg-nightly
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@release/26.10
     if: always()
     with:
@@ -373,21 +372,6 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
-      script: ci/test_wheel_cugraph-pyg.sh
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-  wheel-tests-cugraph-pyg-nightly:
-    needs: [wheel-build-pylibwholegraph, wheel-build-cugraph-pyg, changed-files]
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.10
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
-    with:
-      build_type: pull-request
-      matrix_type: nightly
       script: ci/test_wheel_cugraph-pyg.sh
     permissions:
       actions: read

--- a/ci/download-torch-wheels.sh
+++ b/ci/download-torch-wheels.sh
@@ -17,16 +17,6 @@ set -e -u -o pipefail
 
 TORCH_WHEEL_DIR="${1}"
 
-# skip download attempt on CUDA versions where we know there isn't a 'torch' CUDA wheel.
-CUDA_MAJOR="${RAPIDS_CUDA_VERSION%%.*}"
-CUDA_MINOR=$(echo "${RAPIDS_CUDA_VERSION}" | cut -d'.' -f2)
-if \
-    { [ "${CUDA_MAJOR}" -eq 12 ] && [ "${CUDA_MINOR}" -lt 9 ]; } \
-then
-    rapids-logger "Skipping 'torch' wheel download. (requires CUDA 12.9+, found ${RAPIDS_CUDA_VERSION})"
-    exit 0
-fi
-
 # Ensure CUDA-enabled 'torch' packages are always used.
 #
 # Downloading + passing the downloaded file as a requirement forces the use of this

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -272,24 +272,13 @@ dependencies:
           - matrix:
               use_cuda_wheels: "false"
             packages:
+          # treat any 12.x < 12.8 as "old CUDA 12" for testing purposes. There are not compatible
+          # 'torch' wheels as far back as CUDA 12.2
           - matrix:
-              arch: aarch64
-              cuda: "12.2"
+              cuda: "12.[01234567]"
               use_cuda_wheels: "true"
             packages:
-              # some components (like nvidia-cublas-cu12 and nvidia-cuda-nvcc-cu12) didn't have
-              # aarch64 wheels until CTK 12.3, so allow a slightly looser bound here
-              - cuda-toolkit>=12.2,<12.4
-          - matrix:
-              cuda: "12.2"
-              use_cuda_wheels: "true"
-            packages:
-              - cuda-toolkit==12.2.*
-          - matrix:
-              cuda: "12.5"
-              use_cuda_wheels: "true"
-            packages:
-              - cuda-toolkit==12.5.*
+              - cuda-toolkit>=12.2,<12.7
           - matrix:
               cuda: "12.8"
               use_cuda_wheels: "true"
@@ -484,6 +473,13 @@ dependencies:
           - matrix:
               no_pytorch: "true"
             packages:
+          # treat any 12.x < 12.8 as "old CUDA 12", and install a compatible 'torch' wheel
+          - matrix:
+              cuda: "12.[01234567]"
+              require_gpu: "true"
+            packages:
+              - --extra-index-url=https://download.pytorch.org/whl/cu126
+              - torch==2.14.0+cu126
           # matrices below ensure CUDA 'torch' packages are used
           - matrix:
               arch: aarch64
@@ -507,7 +503,7 @@ dependencies:
               require_gpu: "true"
             packages:
               - *torch_cu129_index
-              - torch==2.10.0+cu129
+              - torch==2.13.0+cu129
           - matrix:
               cuda: "13.0"
               dependencies: "oldest"
@@ -532,7 +528,7 @@ dependencies:
               require_gpu: "true"
             packages:
               - --extra-index-url https://download.pytorch.org/whl/cu132
-              - torch==2.13.0+cu132
+              - torch==2.14.0+cu132
           - matrix:
             packages:
   depends_on_nccl:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/327

Closes https://github.com/rapidsai/build-planning/issues/289

There are official PyTorch 2.14 wheels now. Let's test against them.

## Notes for Reviewers

### How I tested this

Triggered a CI run with both the PR and nightly matrices, to be sure we cover all combinations. Saw them all pass!

https://github.com/rapidsai/cugraph-gnn/actions/runs/34301545068/job/102311876311?pr=537