### PR TITLE
Update pip devcontainers to UCX 1.21

### DIFF
--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:26.12-cpp-cuda12.9-ucx1.19.0-openmpi5.0.10"
+      "BASE": "rapidsai/devcontainers:26.12-cpp-cuda12.9-ucx1.21.0-openmpi5.0.10"
     },
     "cacheFrom": [
       "ghcr.io/rapidsai/cugraph-gnn/devcontainer:26.12-cuda12.9-pip"

--- a/.devcontainer/cuda13.3-pip/devcontainer.json
+++ b/.devcontainer/cuda13.3-pip/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "13.3",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:26.12-cpp-cuda13.3-ucx1.19.0-openmpi5.0.10"
+      "BASE": "rapidsai/devcontainers:26.12-cpp-cuda13.3-ucx1.21.0-openmpi5.0.10"
     },
     "cacheFrom": [
       "ghcr.io/rapidsai/cugraph-gnn/devcontainer:26.12-cuda13.3-pip"

--- a/python/pylibwholegraph/pylibwholegraph/tests/pylibwholegraph/test_tensor_file_formats_io.py
+++ b/python/pylibwholegraph/pylibwholegraph/tests/pylibwholegraph/test_tensor_file_formats_io.py
@@ -34,9 +34,7 @@ torch = pytest.importorskip("torch")
 _GPU_COUNT = None
 _MAX_OVERHEAD_GROWTH = 32 * 1024 * 1024
 _SCALING_DATASET_SIZES_MIB = (32, 128)
-_RUN_PARQUET_MEMORY_TESTS = (
-    os.getenv("PYLIBWHOLEGRAPH_RUN_PARQUET_MEMORY_TESTS") == "1"
-)
+_RUN_PARQUET_MEMORY_TESTS = os.getenv("PYLIBWHOLEGRAPH_RUN_PARQUET_MEMORY_TESTS") == "1"
 _parquet_memory_test = pytest.mark.skipif(
     not _RUN_PARQUET_MEMORY_TESTS,
     reason=(


### PR DESCRIPTION
This updates pip devcontainers from UCX 1.19 to UCX 1.21.

Part of https://github.com/rapidsai/build-planning/issues/314.
