### PR TITLE
docs-build: make use of 'cpu8' runners explicit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,7 +96,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       matrix_name: docs-build
   docs-build:
-    needs: cpp-build
+    needs: [docs-build-matrix, cpp-build]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.10
     strategy:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,7 +96,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       matrix_name: docs-build
   docs-build:
-    needs: [docs-build-matrix, cpp-build]
+    needs: cpp-build
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.10
     strategy:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,6 +98,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       container_image: "rapidsai/ci-conda:26.10-latest"
       date: ${{ inputs.date }}
+      node_type: "cpu8"
       script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}
     permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,15 +88,25 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
+  docs-build-matrix:
+    permissions:
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.10
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      matrix_name: docs-build
   docs-build:
     needs: cpp-build
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.10
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.docs-build-matrix.outputs.matrix) }}
     with:
-      arch: "amd64"
+      arch: "${{ matrix.arch }}"
       branch: ${{ inputs.branch }}
       build_type: ${{ inputs.build_type || 'branch' }}
-      container_image: "rapidsai/ci-conda:26.10-latest"
+      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       date: ${{ inputs.date }}
       script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,25 +88,15 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-  docs-build-matrix:
-    permissions:
-      contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.10
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      matrix_name: docs-build
   docs-build:
     needs: cpp-build
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.10
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.docs-build-matrix.outputs.matrix) }}
     with:
-      arch: "${{ matrix.arch }}"
+      arch: "amd64"
       branch: ${{ inputs.branch }}
       build_type: ${{ inputs.build_type || 'branch' }}
-      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+      container_image: "rapidsai/ci-conda:26.10-latest"
       date: ${{ inputs.date }}
       script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,6 +21,7 @@ jobs:
       - conda-python-build-noarch
       - conda-python-tests
       - docs-build
+      - docs-build-matrix
       - wheel-build-libwholegraph
       - wheel-build-pylibwholegraph
       - wheel-tests-pylibwholegraph
@@ -277,15 +278,25 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
+  docs-build-matrix:
+    permissions:
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.10
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      matrix_name: docs-build
   docs-build:
-    needs: [conda-cpp-build, changed-files]
+    needs: [docs-build-matrix, conda-cpp-build, changed-files]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.10
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.docs-build-matrix.outputs.matrix) }}
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
     with:
-      arch: "amd64"
+      arch: "${{ matrix.arch }}"
       build_type: pull-request
-      container_image: "rapidsai/ci-conda:26.10-latest"
+      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       script: "ci/build_docs.sh"
     permissions:
       actions: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,7 +21,6 @@ jobs:
       - conda-python-build-noarch
       - conda-python-tests
       - docs-build
-      - docs-build-matrix
       - wheel-build-libwholegraph
       - wheel-build-pylibwholegraph
       - wheel-tests-pylibwholegraph
@@ -278,25 +277,15 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-  docs-build-matrix:
-    permissions:
-      contents: read
-    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.10
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      matrix_name: docs-build
   docs-build:
-    needs: [docs-build-matrix, conda-cpp-build, changed-files]
+    needs: [conda-cpp-build, changed-files]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@release/26.10
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.docs-build-matrix.outputs.matrix) }}
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
     with:
-      arch: "${{ matrix.arch }}"
+      arch: "amd64"
       build_type: pull-request
-      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+      container_image: "rapidsai/ci-conda:26.10-latest"
       script: "ci/build_docs.sh"
     permissions:
       actions: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -283,7 +283,7 @@ jobs:
       contents: read
     uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.10
     with:
-      build_type: pull-request
+      build_type: ${{ inputs.build_type || 'branch' }}
       matrix_name: docs-build
   docs-build:
     needs: [docs-build-matrix, conda-cpp-build, changed-files]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -283,7 +283,7 @@ jobs:
       contents: read
     uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@release/26.10
     with:
-      build_type: ${{ inputs.build_type || 'branch' }}
+      build_type: pull-request
       matrix_name: docs-build
   docs-build:
     needs: [docs-build-matrix, conda-cpp-build, changed-files]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -286,6 +286,7 @@ jobs:
       arch: "amd64"
       build_type: pull-request
       container_image: "rapidsai/ci-conda:26.10-latest"
+      node_type: "cpu8"
       script: "ci/build_docs.sh"
     permissions:
       actions: read


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/333

~Updates to hopefully reduce how often `docs-build` jobs get stuck waiting for CI runners.~

~* switches those jobs to RTX Pro 6000 runners~
~* uses shared `docs-build` matrix to set job details~

After initially opening this to switch the type of GPU runner used (as I'm doing across the rest of RAPIDS), I realize that this repo's actually using CPU-only runners for its docs builds.

That wasn't obvious because it's implicitly relying on the default value here: https://github.com/rapidsai/shared-workflows/blob/e9a2657b6a56aae9f8fe2ef4bc8e613fd79438d4/.github/workflows/custom-job.yaml#L41

This PR makes that explicit.
